### PR TITLE
refactor: rename admin references to owner in setup and invitation logic

### DIFF
--- a/task-management/domain/constant/global_setting_const.go
+++ b/task-management/domain/constant/global_setting_const.go
@@ -1,6 +1,6 @@
 package constant
 
 const (
-	GlobalSettingKeyIsSetupAdmin     = "IS_SETUP_ADMIN"
+	GlobalSettingKeyIsSetupOwner     = "IS_SETUP_OWNER"
 	GlobalSettingKeyIsSetupWorkspace = "IS_SETUP_WORKSPACE"
 )

--- a/task-management/domain/exceptions/setup_exceptions.go
+++ b/task-management/domain/exceptions/setup_exceptions.go
@@ -4,6 +4,6 @@ import "errors"
 
 var (
 	ErrWorkspaceAlreadySetup = errors.New("workspace already setup")
-	ErrAdminAlreadySetup     = errors.New("admin already setup")
-	ErrAdminNotSetup         = errors.New("admin not setup")
+	ErrOwnerAlreadySetup     = errors.New("owner already setup")
+	ErrOwnerNotSetup         = errors.New("owner not setup")
 )

--- a/task-management/domain/models/workspace.go
+++ b/task-management/domain/models/workspace.go
@@ -26,8 +26,9 @@ type WorkspaceMember struct {
 type WorkspaceMemberRole string
 
 const (
-	WorkspaceMemberRoleAdmin WorkspaceMemberRole = "ADMIN"
-	WorkspaceMemberRoleUser  WorkspaceMemberRole = "MEMBER"
+	WorkspaceMemberRoleOwner     WorkspaceMemberRole = "OWNER"
+	WorkspaceMemberRoleModerator WorkspaceMemberRole = "MODERATOR"
+	WorkspaceMemberRoleMember    WorkspaceMemberRole = "MEMBER"
 )
 
 func (w WorkspaceMemberRole) String() string {
@@ -36,7 +37,7 @@ func (w WorkspaceMemberRole) String() string {
 
 func (w WorkspaceMemberRole) IsValid() bool {
 	switch w {
-	case WorkspaceMemberRoleAdmin, WorkspaceMemberRoleUser:
+	case WorkspaceMemberRoleOwner, WorkspaceMemberRoleModerator, WorkspaceMemberRoleMember:
 		return true
 	}
 	return false

--- a/task-management/domain/requests/invitation_request.go
+++ b/task-management/domain/requests/invitation_request.go
@@ -6,7 +6,7 @@ type CreateInvitationRequest struct {
 	CustomMessage string `json:"customMessage"`
 }
 
-type ListInvitationForAdminQueryParams struct {
+type ListInvitationForWorkspaceOwnerQueryParams struct {
 	WorkspaceID       string            `param:"workspaceId" validate:"required"`
 	Keyword           string            `query:"keyword"`
 	SearchBy          string            `query:"searchBy"`

--- a/task-management/domain/responses/common_response.go
+++ b/task-management/domain/responses/common_response.go
@@ -12,6 +12,6 @@ type PaginationResponse struct {
 }
 
 type SetupStatusResponse struct {
-	IsSetupAdmin     bool `json:"isSetupAdmin"`
+	IsSetupOwner     bool `json:"isSetupOwner"`
 	IsSetupWorkspace bool `json:"isSetupWorkspace"`
 }

--- a/task-management/domain/responses/invitation_response.go
+++ b/task-management/domain/responses/invitation_response.go
@@ -25,12 +25,12 @@ type InvitationForUserResponse struct {
 	RespondedAt        *time.Time `json:"respondedAt"`
 }
 
-type ListInvitationForAdminResponse struct {
-	Invitations        []InvitationForAdminResponse `json:"invitations"`
+type ListInvitationForWorkspaceOwnerResponse struct {
+	Invitations        []InvitationForWorkspaceOwnerResponse `json:"invitations"`
 	PaginationResponse PaginationResponse           `json:"paginationResponse"`
 }
 
-type InvitationForAdminResponse struct {
+type InvitationForWorkspaceOwnerResponse struct {
 	InvitationID       string     `json:"invitationId"`
 	WorkspaceID        string     `json:"workspaceId"`
 	WorkspaceName      string     `json:"workspaceName"`

--- a/task-management/domain/services/common_service.go
+++ b/task-management/domain/services/common_service.go
@@ -31,13 +31,13 @@ func (c *commonService) GetSetupStatus(ctx context.Context) (*responses.SetupSta
 		return nil, errutils.NewError(err, errutils.InternalServerError)
 	}
 
-	isSetupAdmin, err := c.globalSettingRepo.GetByKey(ctx, constant.GlobalSettingKeyIsSetupAdmin)
+	isSetupOwner, err := c.globalSettingRepo.GetByKey(ctx, constant.GlobalSettingKeyIsSetupOwner)
 	if err != nil {
 		return nil, errutils.NewError(err, errutils.InternalServerError)
 	}
 
 	return &responses.SetupStatusResponse{
 		IsSetupWorkspace: isSetupWorkspace.Value.(bool),
-		IsSetupAdmin:     isSetupAdmin.Value.(bool),
+		IsSetupOwner:     isSetupOwner.Value.(bool),
 	}, nil
 }

--- a/task-management/domain/services/workspace_service.go
+++ b/task-management/domain/services/workspace_service.go
@@ -55,15 +55,15 @@ func (w *workspaceServiceImpl) SetupWorkspace(ctx context.Context, req *requests
 		return nil, errutils.NewError(exceptions.ErrWorkspaceAlreadySetup, errutils.BadRequest)
 	}
 
-	// Check is setup admin
-	isSetupAdmin, err := w.globalSettingRepo.GetByKey(ctx, constant.GlobalSettingKeyIsSetupAdmin)
+	// Check is setup owner
+	isSetupOwner, err := w.globalSettingRepo.GetByKey(ctx, constant.GlobalSettingKeyIsSetupOwner)
 	if err != nil {
 		return nil, errutils.NewError(err, errutils.InternalServerError)
 	}
 
-	if isSetupAdmin == nil {
+	if isSetupOwner == nil {
 		err := w.globalSettingRepo.Set(ctx, &models.GlobalSetting{
-			Key:   constant.GlobalSettingKeyIsSetupAdmin,
+			Key:   constant.GlobalSettingKeyIsSetupOwner,
 			Type:  models.GlobalSettingTypeBool,
 			Value: false,
 		})
@@ -73,8 +73,8 @@ func (w *workspaceServiceImpl) SetupWorkspace(ctx context.Context, req *requests
 		}
 	}
 
-	if !isSetupAdmin.Value.(bool) {
-		return nil, errutils.NewError(exceptions.ErrAdminNotSetup, errutils.BadRequest)
+	if !isSetupOwner.Value.(bool) {
+		return nil, errutils.NewError(exceptions.ErrOwnerNotSetup, errutils.BadRequest)
 	}
 
 	userObjID, err := bson.ObjectIDFromHex(userID)

--- a/task-management/internal/adapters/repositories/mongo/mongo_workspace_repo.go
+++ b/task-management/internal/adapters/repositories/mongo/mongo_workspace_repo.go
@@ -92,7 +92,7 @@ func (m *mongoWorkspaceRepo) Create(ctx context.Context, workspace *repositories
 			{
 				UserID:    workspace.UserID,
 				Name:      workspace.UserName,
-				Role:      models.WorkspaceMemberRoleAdmin,
+				Role:      models.WorkspaceMemberRoleOwner,
 				JoinedAt:  time.Now(),
 				RemovedAt: nil,
 			},

--- a/task-management/internal/adapters/rest/invitation_handler.go
+++ b/task-management/internal/adapters/rest/invitation_handler.go
@@ -14,7 +14,7 @@ import (
 type InvitationHandler interface {
 	Create(c echo.Context) error
 	ListForUser(c echo.Context) error
-	ListForAdmin(c echo.Context) error
+	ListForWorkspaceOwner(c echo.Context) error
 	UserResponse(c echo.Context) error
 }
 
@@ -57,14 +57,14 @@ func (u *invitationHandlerImpl) ListForUser(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-func (u *invitationHandlerImpl) ListForAdmin(c echo.Context) error {
-	queryParams := new(requests.ListInvitationForAdminQueryParams)
+func (u *invitationHandlerImpl) ListForWorkspaceOwner(c echo.Context) error {
+	queryParams := new(requests.ListInvitationForWorkspaceOwnerQueryParams)
 	if err := c.Bind(queryParams); err != nil {
 		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
 	}
 
 	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
-	res, err := u.invitationService.ListForAdmin(c.Request().Context(), queryParams, userClaims.ID)
+	res, err := u.invitationService.ListForWorkspaceOwner(c.Request().Context(), queryParams, userClaims.ID)
 	if err != nil {
 		return err.ToEchoError()
 	}

--- a/task-management/internal/adapters/rest/user_handler.go
+++ b/task-management/internal/adapters/rest/user_handler.go
@@ -104,7 +104,7 @@ func (u *userHandlerImpl) SetupUser(c echo.Context) error {
 		return err
 	}
 
-	user, err := u.userService.SetupUser(c.Request().Context(), req)
+	user, err := u.userService.SetupFirstUser(c.Request().Context(), req)
 	if err != nil {
 		return err.ToEchoError()
 	}

--- a/task-management/internal/infrastructure/router/api_router.go
+++ b/task-management/internal/infrastructure/router/api_router.go
@@ -21,7 +21,7 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 	{
 		invitations.POST("", r.invitation.Create, r.authMiddleware.Middleware)
 		invitations.GET("/users", r.invitation.ListForUser, r.authMiddleware.Middleware)
-		invitations.GET("/:workspaceId/workspaces/admin", r.invitation.ListForAdmin, r.authMiddleware.Middleware)
+		invitations.GET("/:workspaceId/workspaces/owner", r.invitation.ListForWorkspaceOwner, r.authMiddleware.Middleware)
 		invitations.PUT("/users", r.invitation.UserResponse, r.authMiddleware.Middleware)
 	}
 


### PR DESCRIPTION
This pull request includes significant changes to update the terminology and role definitions within the task management system. The most important changes involve renaming "Admin" to "Owner" across various files and methods, and adding new roles such as "Moderator" and "Member".

### Terminology and Role Updates:

* [`task-management/domain/constant/global_setting_const.go`](diffhunk://#diff-e1807d90ee2b9f9f5d7bedc25bdec0ba6c9f83f2ae38e8dcba4ea2bf99cc363fL4-R4): Renamed `GlobalSettingKeyIsSetupAdmin` to `GlobalSettingKeyIsSetupOwner`.
* [`task-management/domain/exceptions/setup_exceptions.go`](diffhunk://#diff-5663802146db07112e3bcdcabf1b2c775ad05bfc6fb464a95edbfa16124079a2L7-R8): Updated error messages to replace "Admin" with "Owner".
* [`task-management/domain/models/workspace.go`](diffhunk://#diff-62685f44a770f243ba61ceae31463f6eb541ecebc89132ad67eb2250ac64fe31L29-R31): Changed `WorkspaceMemberRoleAdmin` to `WorkspaceMemberRoleOwner` and added new roles `Moderator` and `Member`. [[1]](diffhunk://#diff-62685f44a770f243ba61ceae31463f6eb541ecebc89132ad67eb2250ac64fe31L29-R31) [[2]](diffhunk://#diff-62685f44a770f243ba61ceae31463f6eb541ecebc89132ad67eb2250ac64fe31L39-R40)

### Method and Function Updates:

* [`task-management/domain/requests/invitation_request.go`](diffhunk://#diff-3eb6111ec3ac5be93f5dbf2239773fed06814583160c6266f799c44df790ddbaL9-R9): Renamed `ListInvitationForAdminQueryParams` to `ListInvitationForWorkspaceOwnerQueryParams`.
* [`task-management/domain/responses/invitation_response.go`](diffhunk://#diff-343f6234b6a25b9ee8935466cd05c94e9cebb47da2914f5b72cf213484b1a541L28-R33): Updated response types from "Admin" to "WorkspaceOwner".

### Service Layer Changes:

* [`task-management/domain/services/common_service.go`](diffhunk://#diff-d1cae9f652bb95120b6f5eff7164afcb7ebde7f482127817aaebee670afc85b0L34-R41): Updated the `GetSetupStatus` method to check for `GlobalSettingKeyIsSetupOwner` instead of `GlobalSettingKeyIsSetupAdmin`.
* [`task-management/domain/services/invitation_service.go`](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL23-R23): Renamed various methods and validation functions to replace "Admin" with "WorkspaceOwner". [[1]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL23-R23) [[2]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL59-R66) [[3]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL157-R174) [[4]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL185-R185) [[5]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL210-R217) [[6]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL235-R235) [[7]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL257-R257) [[8]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL276-R276) [[9]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dL324-R324)

### Handler and Router Updates:

* [`task-management/internal/adapters/rest/invitation_handler.go`](diffhunk://#diff-fb237cae94617d04ac36a1454c2dda5ac551351be2cd03f63f0347126392955dL17-R17): Updated the handler method names to reflect the change from "Admin" to "WorkspaceOwner". [[1]](diffhunk://#diff-fb237cae94617d04ac36a1454c2dda5ac551351be2cd03f63f0347126392955dL17-R17) [[2]](diffhunk://#diff-fb237cae94617d04ac36a1454c2dda5ac551351be2cd03f63f0347126392955dL60-R67)
* [`task-management/internal/infrastructure/router/api_router.go`](diffhunk://#diff-e37120c229ae801fdac79f09749572f514eb0e45dfeb42a2a4c14701b06ed9acL24-R24): Modified the API routes to use "owner" instead of "admin".

These changes ensure consistency in terminology and expand the role definitions to provide more granular control within the workspace.