### PR TITLE
feat: add role to invitation and implement endpoint to list own workspaces

### DIFF
--- a/task-management/domain/models/invitation.go
+++ b/task-management/domain/models/invitation.go
@@ -10,12 +10,32 @@ type Invitation struct {
 	ID            bson.ObjectID    `bson:"_id" json:"id"`
 	WorkspaceID   bson.ObjectID    `bson:"workspace_id" json:"workspaceId"`
 	InviteeUserID bson.ObjectID    `bson:"invitee_user_id" json:"inviteeUserId"`
+	Role          InvitationRole   `bson:"role" json:"role"`
 	Status        InvitationStatus `bson:"status" json:"status"`
 	ExpiredAt     time.Time        `bson:"expired_at" json:"expiredAt"`
 	RespondedAt   *time.Time       `bson:"responded_at" json:"respondedAt"`
 	CustomMessage *string          `bson:"custom_message" json:"customMessage"`
 	CreatedAt     time.Time        `bson:"created_at" json:"createdAt"`
 	CreatedBy     bson.ObjectID    `bson:"created_by" json:"createdBy"`
+}
+
+type InvitationRole string
+
+const (
+	InvitationRoleModerator InvitationRole = "MODERATOR"
+	InvitationRoleUser      InvitationRole = "MEMBER"
+)
+
+func (i InvitationRole) String() string {
+	return string(i)
+}
+
+func (i InvitationRole) IsValid() bool {
+	switch i {
+	case InvitationRoleModerator, InvitationRoleUser:
+		return true
+	}
+	return false
 }
 
 type InvitationStatus string

--- a/task-management/domain/repositories/invitation_repo.go
+++ b/task-management/domain/repositories/invitation_repo.go
@@ -20,6 +20,7 @@ type InvitationRepository interface {
 type CreateInvitationRequest struct {
 	WorkspaceID   bson.ObjectID
 	InviteeUserID bson.ObjectID
+	Role          models.InvitationRole
 	Status        models.InvitationStatus
 	ExpiredAt     time.Time
 	CustomMessage string

--- a/task-management/domain/repositories/workspace_repo.go
+++ b/task-management/domain/repositories/workspace_repo.go
@@ -12,6 +12,7 @@ type WorkspaceRepository interface {
 	FindByID(ctx context.Context, workspaceID bson.ObjectID) (*models.Workspace, error)
 	CreateWorkspaceMember(ctx context.Context, req *CreateWorkspaceMemberRequest) error
 	Create(ctx context.Context, workspace *CreateWorkspaceRequest) (*models.Workspace, error)
+	FindByUserID(ctx context.Context, userID bson.ObjectID) ([]*models.Workspace, error)
 }
 
 type CreateWorkspaceMemberRequest struct {

--- a/task-management/domain/requests/invitation_request.go
+++ b/task-management/domain/requests/invitation_request.go
@@ -3,13 +3,14 @@ package requests
 type CreateInvitationRequest struct {
 	WorkspaceID   string `json:"workspaceId" validate:"required"`
 	InviteeUserID string `json:"inviteeUserId" validate:"required"`
+	Role          string `json:"role" validate:"required,oneof=MODERATOR MEMBER"`
 	CustomMessage string `json:"customMessage"`
 }
 
 type ListInvitationForWorkspaceOwnerQueryParams struct {
-	WorkspaceID       string            `param:"workspaceId" validate:"required"`
-	Keyword           string            `query:"keyword"`
-	SearchBy          string            `query:"searchBy"`
+	WorkspaceID       string             `param:"workspaceId" validate:"required"`
+	Keyword           string             `query:"keyword"`
+	SearchBy          string             `query:"searchBy"`
 	PaginationRequest *PaginationRequest `query:"paginationRequest"`
 }
 

--- a/task-management/domain/responses/invitation_response.go
+++ b/task-management/domain/responses/invitation_response.go
@@ -14,6 +14,7 @@ type InvitationForUserResponse struct {
 	InvitationID       string     `json:"invitationId"`
 	WorkspaceID        string     `json:"workspaceId"`
 	WorkspaceName      string     `json:"workspaceName"`
+	Role               string     `json:"role"`
 	Status             string     `json:"status"`
 	CustomMessage      *string    `json:"customMessage"`
 	InvitedAt          string     `json:"invitedAt"`
@@ -27,13 +28,14 @@ type InvitationForUserResponse struct {
 
 type ListInvitationForWorkspaceOwnerResponse struct {
 	Invitations        []InvitationForWorkspaceOwnerResponse `json:"invitations"`
-	PaginationResponse PaginationResponse           `json:"paginationResponse"`
+	PaginationResponse PaginationResponse                    `json:"paginationResponse"`
 }
 
 type InvitationForWorkspaceOwnerResponse struct {
 	InvitationID       string     `json:"invitationId"`
 	WorkspaceID        string     `json:"workspaceId"`
 	WorkspaceName      string     `json:"workspaceName"`
+	Role               string     `json:"role"`
 	Status             string     `json:"status"`
 	CustomMessage      *string    `json:"customMessage"`
 	InvitedAt          string     `json:"invitedAt"`

--- a/task-management/domain/services/workspace_service.go
+++ b/task-management/domain/services/workspace_service.go
@@ -14,6 +14,7 @@ import (
 
 type WorkspaceService interface {
 	SetupWorkspace(ctx context.Context, req *requests.CreateWorkspaceRequest, userID string) (*models.Workspace, *errutils.Error)
+	ListOwnWorkspace(ctx context.Context, userId string) ([]*models.Workspace, *errutils.Error)
 }
 
 type workspaceServiceImpl struct {
@@ -109,5 +110,23 @@ func (w *workspaceServiceImpl) SetupWorkspace(ctx context.Context, req *requests
 		Type:  models.GlobalSettingTypeBool,
 		Value: true,
 	})
+	if err != nil {
+		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+	}
+
 	return workspace, nil
+}
+
+func (s *workspaceServiceImpl) ListOwnWorkspace(ctx context.Context, userId string) ([]*models.Workspace, *errutils.Error) {
+	userObjID, err := bson.ObjectIDFromHex(userId)
+	if err != nil {
+		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+	}
+
+	workspaces, err := s.workspaceRepo.FindByUserID(ctx, userObjID)
+	if err != nil {
+		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+	}
+
+	return workspaces, nil
 }

--- a/task-management/internal/adapters/repositories/mongo/mongo_invitation_repo.go
+++ b/task-management/internal/adapters/repositories/mongo/mongo_invitation_repo.go
@@ -67,6 +67,7 @@ func (m *mongoInvitationRepo) Create(ctx context.Context, invitation *repositori
 		ID:            bson.NewObjectID(),
 		WorkspaceID:   invitation.WorkspaceID,
 		InviteeUserID: invitation.InviteeUserID,
+		Role:          invitation.Role,
 		Status:        invitation.Status,
 		ExpiredAt:     invitation.ExpiredAt,
 		CustomMessage: &invitation.CustomMessage,
@@ -138,7 +139,7 @@ func (m *mongoInvitationRepo) SearchInvitationForEachWorkspaceRequest(ctx contex
 				{"custom_message": bson.M{"$regex": in.Keyword, "$options": "i"}},
 			}
 		}
-	} 
+	}
 
 	findOptions := options.Find()
 	findOptions.SetSkip(int64((in.PaginationRequest.Page - 1) * in.PaginationRequest.PageSize))

--- a/task-management/internal/adapters/repositories/mongo/mongo_workspace_repo.go
+++ b/task-management/internal/adapters/repositories/mongo/mongo_workspace_repo.go
@@ -73,9 +73,10 @@ func (m *mongoWorkspaceRepo) CreateWorkspaceMember(ctx context.Context, in *repo
 	update := bson.M{
 		"$push": bson.M{
 			"members": models.WorkspaceMember{
-				UserID: in.UserID,
-				Name:   in.Name,
-				Role:   in.Role,
+				UserID:   in.UserID,
+				Name:     in.Name,
+				Role:     in.Role,
+				JoinedAt: time.Now(),
 			},
 		},
 	}
@@ -109,4 +110,25 @@ func (m *mongoWorkspaceRepo) Create(ctx context.Context, workspace *repositories
 
 	workspaceModel.ID = res.InsertedID.(bson.ObjectID)
 	return &workspaceModel, nil
+}
+
+func (m *mongoWorkspaceRepo) FindByUserID(ctx context.Context, userID bson.ObjectID) ([]*models.Workspace, error) {
+	f := NewWorkspaceFilter()
+	f.WithMemberUserID(userID)
+
+	cursor, err := m.collection.Find(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	var workspaces []*models.Workspace
+	for cursor.Next(ctx) {
+		var workspace models.Workspace
+		if err := cursor.Decode(&workspace); err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, &workspace)
+	}
+
+	return workspaces, nil
 }

--- a/task-management/internal/adapters/rest/workspace_handler.go
+++ b/task-management/internal/adapters/rest/workspace_handler.go
@@ -13,6 +13,7 @@ import (
 
 type WorkspaceHandler interface {
 	SetupWorkspace(c echo.Context) error
+	ListOwnWorkspace(c echo.Context) error
 }
 
 type workspaceHandlerImpl struct {
@@ -43,4 +44,15 @@ func (w *workspaceHandlerImpl) SetupWorkspace(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusCreated, workspace)
+}
+
+func (w *workspaceHandlerImpl) ListOwnWorkspace(c echo.Context) error {
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+
+	workspaces, err := w.workspaceService.ListOwnWorkspace(c.Request().Context(), userClaims.ID)
+	if err != nil {
+		return err.ToEchoError()
+	}
+
+	return c.JSON(http.StatusOK, workspaces)
 }

--- a/task-management/internal/infrastructure/router/api_router.go
+++ b/task-management/internal/infrastructure/router/api_router.go
@@ -17,6 +17,11 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 		auth.GET("/search", r.user.SearchUser, r.authMiddleware.Middleware)
 	}
 
+	workspaces := api.Group("/workspaces/v1")
+	{
+		workspaces.GET("/own-workspaces", r.workspace.ListOwnWorkspace, r.authMiddleware.Middleware)
+	}
+
 	invitations := api.Group("/invitations/v1")
 	{
 		invitations.POST("", r.invitation.Create, r.authMiddleware.Middleware)


### PR DESCRIPTION
This pull request introduces several changes to the invitation and workspace management features in the `task-management` system. The main changes include adding a role to invitations, allowing users to list their own workspaces, and various adjustments to repository and service methods to accommodate these new features.

### Invitation Role Management:
* Added `Role` field to the `Invitation` struct and created the `InvitationRole` type with constants for "MODERATOR" and "MEMBER" roles. [[1]](diffhunk://#diff-5597a24ce639f8f83fe4d31a5a8f02c34cca416cbbf73a871baf52fff170026dR13) [[2]](diffhunk://#diff-5597a24ce639f8f83fe4d31a5a8f02c34cca416cbbf73a871baf52fff170026dR22-R40)
* Updated `CreateInvitationRequest` to include the `Role` field.
* Modified `CreateInvitationRequest` in `invitation_request.go` to validate the `Role` field.
* Updated `InvitationForUserResponse` and `InvitationForWorkspaceOwnerResponse` to include the `Role` field. [[1]](diffhunk://#diff-343f6234b6a25b9ee8935466cd05c94e9cebb47da2914f5b72cf213484b1a541R17) [[2]](diffhunk://#diff-343f6234b6a25b9ee8935466cd05c94e9cebb47da2914f5b72cf213484b1a541R38)

### Workspace Management:
* Added `FindByUserID` method to `WorkspaceRepository` and implemented it in the MongoDB adapter. [[1]](diffhunk://#diff-f2fccc06f31f7fecff5a59bd469ebbc9ec10b6de76dd61a4270dd7e6b68a9c7aR15) [[2]](diffhunk://#diff-c3294e589eabe5315b866e262796ce73a1df4885fabd90dacefcda72a1ff3e5eR114-R134)
* Added `ListOwnWorkspace` method to `WorkspaceService` and implemented it in the service and handler. [[1]](diffhunk://#diff-b374e70c063ab3449aae329e6a7cb2f33712f4fb9182c17c4c247650c6665c43R17) [[2]](diffhunk://#diff-b374e70c063ab3449aae329e6a7cb2f33712f4fb9182c17c4c247650c6665c43R113-R132) [[3]](diffhunk://#diff-47d46212fb429b33774bf50811983d847e90af5cbd93970b958acfdd0fb79698R16) [[4]](diffhunk://#diff-47d46212fb429b33774bf50811983d847e90af5cbd93970b958acfdd0fb79698R48-R58)
* Registered the new endpoint `/workspaces/v1/own-workspaces` in the API router.

### Service and Repository Adjustments:
* Updated `Create` method in `invitationServiceImpl` to handle the `Role` field.
* Adjusted `ListForUser` and `ListForWorkspaceOwner` methods to include the `Role` field in the response. [[1]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dR137) [[2]](diffhunk://#diff-e484c9a0909795175d585f37954691b471a403ee26fc1e0b089d4ce53cd2031dR259)
* Modified `UserResponse` method to set the appropriate workspace member role based on the invitation role.
* Added `JoinedAt` field to the `CreateWorkspaceMember` method in the MongoDB adapter.

### Code Cleanup:
* Removed unnecessary `fmt.Println` statements in `ListForUser` method.
* Removed unused `fmt` import in `invitation_service.go`.