### PR TITLE
feat: handle nil workspaces in ListOwnWorkspace method to return empty slice

### DIFF
--- a/task-management/domain/services/workspace_service.go
+++ b/task-management/domain/services/workspace_service.go
@@ -129,5 +129,9 @@ func (s *workspaceServiceImpl) ListOwnWorkspace(ctx context.Context, userId stri
 		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
+	if workspaces == nil {
+		return []*models.Workspace{}, nil
+	}
+
 	return workspaces, nil
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `task-management/domain/services/workspace_service.go` file. The change ensures that the `ListOwnWorkspace` function returns an empty slice instead of `nil` when no workspaces are found.

* [`task-management/domain/services/workspace_service.go`](diffhunk://#diff-b374e70c063ab3449aae329e6a7cb2f33712f4fb9182c17c4c247650c6665c43R132-R135): Added a check to return an empty slice of `models.Workspace` if `workspaces` is `nil`.