### PR TITLE
feat: implement pagination and filtering for listing workspace members

### DIFF
--- a/task-management/domain/repositories/common_repo.go
+++ b/task-management/domain/repositories/common_repo.go
@@ -1,8 +1,8 @@
 package repositories
 
 type PaginationRequest struct {
-	Page     int    `json:"page"`
-	PageSize int    `json:"pageSize"`
-	SortBy   string `json:"sortBy"`
-	Order    string `json:"order"`
+	Page     int
+	PageSize int
+	SortBy   string
+	Order    string
 }

--- a/task-management/domain/requests/workspace_request.go
+++ b/task-management/domain/requests/workspace_request.go
@@ -3,3 +3,9 @@ package requests
 type CreateWorkspaceRequest struct {
 	Name string `json:"name" validate:"required"`
 }
+
+type ListWorkspaceMemberRequest struct {
+	WorkspaceID string `param:"workspaceId" validate:"required"`
+	Keyword     string `json:"keyword"`
+	PaginationRequest
+}

--- a/task-management/domain/responses/workspace_response.go
+++ b/task-management/domain/responses/workspace_response.go
@@ -14,3 +14,19 @@ type ListOwnWorkspaceResponseWorkspace struct {
 	Role     string    `json:"role"`
 	JoinedAt time.Time `json:"joinedAt"`
 }
+
+type ListWorkspaceMembersResponse struct {
+	Members            []ListWorkspaceMembersResponseWorkspaceMember `json:"members"`
+	PaginationResponse PaginationResponse                            `json:"paginationResponse"`
+}
+
+type ListWorkspaceMembersResponseWorkspaceMember struct {
+	WorkspaceMemberID string    `json:"workspaceMemberId"`
+	UserID            string    `json:"userId"`
+	Role              string    `json:"role"`
+	JoinedAt          time.Time `json:"joinedAt"`
+	Email             string    `json:"email"`
+	FullName          string    `json:"fullName"`
+	DisplayName       string    `json:"displayName"`
+	ProfileUrl        string    `json:"profileUrl"`
+}

--- a/task-management/internal/adapters/rest/workspace_handler.go
+++ b/task-management/internal/adapters/rest/workspace_handler.go
@@ -59,9 +59,12 @@ func (w *workspaceHandlerImpl) ListOwnWorkspace(c echo.Context) error {
 }
 
 func (w *workspaceHandlerImpl) ListWorkspaceMembers(c echo.Context) error {
-	workspaceID := c.Param("workspaceId")
+	req := new(requests.ListWorkspaceMemberRequest)
+	if err := c.Bind(req); err != nil {
+		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
+	}
 
-	members, err := w.workspaceService.ListWorkspaceMembers(c.Request().Context(), workspaceID)
+	members, err := w.workspaceService.ListWorkspaceMembers(c.Request().Context(), req)
 	if err != nil {
 		return err.ToEchoError()
 	}


### PR DESCRIPTION
This pull request focuses on enhancing the workspace member listing functionality by introducing pagination and search capabilities. The changes include modifications to request and response structures, service logic, and handler implementations.

Key changes:

### Request and Response Enhancements:
* Added `ListWorkspaceMemberRequest` struct to handle workspace member listing requests with pagination and search parameters (`task-management/domain/requests/workspace_request.go`).
* Introduced `ListWorkspaceMembersResponse` and `ListWorkspaceMembersResponseWorkspaceMember` structs to format the response for workspace member listings (`task-management/domain/responses/workspace_response.go`).

### Service Logic Updates:
* Updated `ListWorkspaceMembers` method in `WorkspaceService` to use the new request and response structures, including pagination and search logic (`task-management/domain/services/workspace_service.go`).
* Implemented helper functions `validateListWorkspaceMembersPaginationRequestSortBy` and `normalizeListWorkspaceMembersPaginationParams` to validate and normalize pagination parameters in the service layer (`task-management/domain/services/workspace_service.go`).

### Handler Modifications:
* Modified `ListWorkspaceMembers` handler to bind the new request struct and pass it to the service layer (`task-management/internal/adapters/rest/workspace_handler.go`).

### Miscellaneous:
* Removed JSON tags from `PaginationRequest` struct fields to simplify internal usage (`task-management/domain/repositories/common_repo.go`).