### PR TITLE
refactor: refactor list-my-projects api path

### DIFF
--- a/task-management/internal/infrastructure/router/api_router.go
+++ b/task-management/internal/infrastructure/router/api_router.go
@@ -21,6 +21,7 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 	{
 		workspaces.GET("/own-workspaces", r.workspace.ListOwnWorkspace, r.authMiddleware.Middleware)
 		workspaces.GET("/:workspaceId/members", r.workspace.ListWorkspaceMembers, r.authMiddleware.Middleware)
+		workspaces.GET("/:workspaceId/my-projects", r.project.ListMyProjects, r.authMiddleware.Middleware)
 	}
 
 	invitations := api.Group("/invitations/v1")
@@ -34,7 +35,6 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 	projects := api.Group("/projects/v1")
 	{
 		projects.POST("", r.project.Create, r.authMiddleware.Middleware)
-		projects.GET("/:workspaceId/my-projects", r.project.ListMyProjects, r.authMiddleware.Middleware)
 		projects.GET("/:projectId", r.project.GetProjectDetail, r.authMiddleware.Middleware)
 
 		// Positions


### PR DESCRIPTION
This pull request includes changes to the `task-management/internal/infrastructure/router/api_router.go` file to improve the routing of project-related API endpoints. The main changes involve the reorganization of the `ListMyProjects` endpoint to be under the workspace routes.

Routing improvements:

* [`task-management/internal/infrastructure/router/api_router.go`](diffhunk://#diff-e37120c229ae801fdac79f09749572f514eb0e45dfeb42a2a4c14701b06ed9acR24): Added the `ListMyProjects` endpoint under the workspace routes.
* [`task-management/internal/infrastructure/router/api_router.go`](diffhunk://#diff-e37120c229ae801fdac79f09749572f514eb0e45dfeb42a2a4c14701b06ed9acL37): Removed the `ListMyProjects` endpoint from the projects routes.