### PR TITLE
feat: add project owner retrieval to project detail response and update ListMyProjects response structure

### DIFF
--- a/domain/repositories/project_member_repo.go
+++ b/domain/repositories/project_member_repo.go
@@ -13,6 +13,7 @@ type ProjectMemberRepository interface {
 	FindByUserID(ctx context.Context, userID bson.ObjectID) ([]*models.ProjectMember, error)
 	FindByProjectID(ctx context.Context, projectID bson.ObjectID) ([]*models.ProjectMember, error)
 	FindByProjectIDAndUserID(ctx context.Context, projectID bson.ObjectID, userID bson.ObjectID) (*models.ProjectMember, error)
+	FindProjectOwnerByProjectID(ctx context.Context, projectID bson.ObjectID) (*models.ProjectMember, error)
 	FindProjectOwnersByProjectIDs(ctx context.Context, projectIDs []bson.ObjectID) (map[bson.ObjectID]models.ProjectMember, error)
 }
 

--- a/domain/responses/project_response.go
+++ b/domain/responses/project_response.go
@@ -13,10 +13,23 @@ type CreateProjectResponse struct {
 }
 
 type ListMyProjectsResponse struct {
-	Projects []ListMyProjectsResponseProject `json:"projects"`
+	ID                   string    `json:"id"`
+	WorkspaceID          string    `json:"workspaceId"`
+	Name                 string    `json:"name"`
+	ProjectPrefix        string    `json:"projectPrefix"`
+	Description          *string   `json:"description"`
+	Status               string    `json:"status"`
+	OwnerUserID          string    `json:"ownerUserId"`
+	OwnerProjectMemberID string    `json:"ownerProjectMemberId"`
+	OwnerDisplayName     string    `json:"ownerDisplayName"`
+	OwnerProfileUrl      string    `json:"ownerProfileUrl"`
+	CreatedAt            time.Time `json:"createdAt"`
+	CreatedBy            string    `json:"createdBy"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	UpdatedBy            string    `json:"updatedBy"`
 }
 
-type ListMyProjectsResponseProject struct {
+type GetMyProjectDetailResponse struct {
 	ID                   string    `json:"id"`
 	WorkspaceID          string    `json:"workspaceId"`
 	Name                 string    `json:"name"`

--- a/internal/adapters/repositories/mongo/mongo_project_member_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_project_member_repo.go
@@ -114,6 +114,23 @@ func (m *mongoProjectMemberRepo) FindByProjectIDAndUserID(ctx context.Context, p
 	return projectMember, nil
 }
 
+func (m *mongoProjectMemberRepo) FindProjectOwnerByProjectID(ctx context.Context, projectID bson.ObjectID) (*models.ProjectMember, error) {
+	f := NewProjectMemberFilter()
+	f.WithProjectID(projectID)
+	f.WithRole(models.ProjectMemberRoleOwner)
+
+	projectMember := new(models.ProjectMember)
+	err := m.collection.FindOne(ctx, f).Decode(projectMember)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return projectMember, nil
+}
+
 func (m *mongoProjectMemberRepo) FindProjectOwnersByProjectIDs(ctx context.Context, projectIDs []bson.ObjectID) (map[bson.ObjectID]models.ProjectMember, error) {
 	f := NewProjectMemberFilter()
 	f.WithProjectIDs(projectIDs)


### PR DESCRIPTION
This pull request includes several changes to the `project_service.go`, `project_member_repo.go`, and `project_response.go` files, primarily focused on enhancing the project-related functionalities and responses. The most important changes include adding a method to find the project owner, modifying response structures, and updating service methods to return more detailed information.

Enhancements to project-related functionalities:

* [`domain/repositories/project_member_repo.go`](diffhunk://#diff-1a248bdb4a986aea5b156a5980a559a91f3e0e4dab5806cc934d206271c493f2R16): Added the `FindProjectOwnerByProjectID` method to the `ProjectMemberRepository` interface to retrieve the project owner by project ID.
* [`internal/adapters/repositories/mongo/mongo_project_member_repo.go`](diffhunk://#diff-8cedf3c7c2415c718a9b8044a0c663887eaf5eadcef439999b93bb6d4220dbceR117-R133): Implemented the `FindProjectOwnerByProjectID` method in the MongoDB repository to find the project owner based on the project ID.

Modifications to response structures:

* [`domain/responses/project_response.go`](diffhunk://#diff-2b926e68740c8befd5dcada9c76280c1b6d0de4eb78c0680ad4da5a61b7d905aL16-R32): Updated the `ListMyProjectsResponse` structure to include additional project details such as `ID`, `WorkspaceID`, `Name`, `ProjectPrefix`, `Description`, `Status`, `OwnerUserID`, `OwnerProjectMemberID`, `OwnerDisplayName`, `OwnerProfileUrl`, `CreatedAt`, `CreatedBy`, `UpdatedAt`, and `UpdatedBy`. Additionally, renamed `ListMyProjectsResponseProject` to `GetMyProjectDetailResponse`.

Updates to service methods:

* [`domain/services/project_service.go`](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL20-R21): Modified the `ListMyProjects` method to return a slice of `ListMyProjectsResponse` instead of a single response object. [[1]](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL20-R21) [[2]](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL130-R130) [[3]](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL176-R176) [[4]](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL187-R187) [[5]](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL205-R208)
* [`domain/services/project_service.go`](diffhunk://#diff-c558893f6ea97e1804535b18deff222dfb40afaad1516ae4de093825bd1b66daL236-R259): Updated the `GetProjectDetail` method to return a `GetMyProjectDetailResponse` object with detailed project and owner information.