### PR TITLE
feat: add FindByTaskRefAndProjectID method and update API routes for project-specific task operations

### DIFF
--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -13,6 +13,7 @@ type TaskRepository interface {
 	FindByID(ctx context.Context, id bson.ObjectID) (*models.Task, error)
 	FindByIDs(ctx context.Context, ids []bson.ObjectID) ([]*models.Task, error)
 	FindByTaskRef(ctx context.Context, taskRef string) (*models.Task, error)
+	FindByTaskRefAndProjectID(ctx context.Context, taskRef string, projectID bson.ObjectID) (*models.Task, error)
 	UpdateDetail(ctx context.Context, in *UpdateTaskDetailRequest) (*models.Task, error)
 	UpdateStatus(ctx context.Context, in *UpdateTaskStatusRequest) (*models.Task, error)
 	UpdateApprovals(ctx context.Context, in *UpdateTaskApprovalsRequest) (*models.Task, error)

--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -1,14 +1,21 @@
 package requests
 
-import "time"
+import (
+	"time"
+)
 
 type CreateTaskRequest struct {
-	ProjectID   string  `json:"projectId" validate:"required"`
+	ProjectID   string  `param:"projectId" validate:"required"`
 	Title       string  `json:"title" validate:"required"`
 	Description string  `json:"description"`
 	ParentID    *string `json:"parentId"`
 	Type        string  `json:"type" validate:"required"`
 	SprintID    *string `json:"sprintId"`
+}
+
+type GetTaskDetailPathParam struct {
+	ProjectID string `param:"projectId" validate:"required"`
+	TaskRef   string `param:"taskRef" validate:"required"`
 }
 
 type ListEpicTasksPathParam struct {
@@ -25,11 +32,8 @@ type SearchTaskParams struct {
 	SearchKeyword *string  `query:"searchKeyword"`
 }
 
-type GetTaskDetailPathParam struct {
-	TaskRef string `param:"taskRef" validate:"required"`
-}
-
 type UpdateTaskDetailRequest struct {
+	ProjectID   string     `param:"projectId" validate:"required"`
 	TaskRef     string     `param:"taskRef" validate:"required"`
 	Title       string     `json:"title" validate:"required"`
 	Description string     `json:"description"`
@@ -40,43 +44,51 @@ type UpdateTaskDetailRequest struct {
 }
 
 type UpdateTaskStatusRequest struct {
-	TaskID string `param:"taskRef" validate:"required"`
-	Status string `json:"status" validate:"required"` // List project's status
+	ProjectID string `param:"projectId" validate:"required"`
+	TaskID    string `param:"taskRef" validate:"required"`
+	Status    string `json:"status" validate:"required"` // List project's status
 }
 
 type UpdateTaskApprovalsRequest struct {
+	ProjectID       string   `param:"projectId" validate:"required"`
 	TaskRef         string   `param:"taskRef" validate:"required"`
 	ApprovalUserIDs []string `json:"approvalUserIds" validate:"required"` // List User in the following project
 }
 
 type ApproveTaskRequest struct {
-	TaskRef string `param:"taskRef" validate:"required"`
-	Reason  string `json:"reason"`
+	ProjectID string `param:"projectId" validate:"required"`
+	TaskRef   string `param:"taskRef" validate:"required"`
+	Reason    string `json:"reason"`
 }
 
 type UpdateTaskAssigneesRequest struct {
+	ProjectID string                               `param:"projectId" validate:"required"`
 	TaskRef   string                               `param:"taskRef" validate:"required"`
 	Assignees []UpdateTaskAssigneesRequestAssignee `json:"assignees" validate:"required,dive"`
 }
 
 type UpdateTaskAssigneesRequestAssignee struct {
-	Position string `json:"position" validate:"required"` // List project's position
-	UserId   string `json:"userId" validate:"required"`   // List User in the following project
-	Point    *int   `json:"point"`
+	ProjectID string `json:"projectId" validate:"required"`
+	Position  string `json:"position" validate:"required"` // List project's position
+	UserId    string `json:"userId" validate:"required"`   // List User in the following project
+	Point     *int   `json:"point"`
 }
 
 type UpdateTaskSprintRequest struct {
+	ProjectID         string   `param:"projectId" validate:"required"`
 	TaskRef           string   `param:"taskRef" validate:"required"`
 	CurrentSprintID   string   `json:"currentSprintId" validate:"required"`
 	PreviousSprintIDs []string `json:"previousSprintIds"`
 }
 
 type UpdateTaskAttributesRequest struct {
+	ProjectID  string                                 `param:"projectId" validate:"required"`
 	TaskRef    string                                 `param:"taskRef" validate:"required"`
 	Attributes []UpdateTaskAttributesRequestAttribute `json:"attributes" validate:"required,dive"`
 }
 
 type UpdateTaskAttributesRequestAttribute struct {
-	Key   string `json:"key" validate:"required"`
-	Value string `json:"value"`
+	ProjectID string `json:"projectId" validate:"required"`
+	Key       string `json:"key" validate:"required"`
+	Value     string `json:"value"`
 }

--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -203,7 +203,12 @@ func (s *taskServiceImpl) GetTaskDetail(ctx context.Context, req *requests.GetTa
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -476,12 +481,17 @@ func (s *taskServiceImpl) UpdateDetail(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
 	// Check if task priority is valid
 	if !models.TaskPriority(req.Priority).IsValid() {
 		return nil, errutils.NewError(exceptions.ErrInvalidTaskPriority, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Invalid task priority: %s", req.Priority))
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -693,7 +703,12 @@ func (s *taskServiceImpl) UpdateStatus(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskID)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskID, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -741,7 +756,12 @@ func (s *taskServiceImpl) UpdateApprovals(ctx context.Context, req *requests.Upd
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -785,7 +805,12 @@ func (s *taskServiceImpl) ApproveTask(ctx context.Context, req *requests.Approve
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -819,7 +844,12 @@ func (s *taskServiceImpl) UpdateAssignees(ctx context.Context, req *requests.Upd
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -965,7 +995,12 @@ func (s *taskServiceImpl) UpdateSprint(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {
@@ -1017,7 +1052,12 @@ func (s *taskServiceImpl) UpdateAttributes(ctx context.Context, req *requests.Up
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
-	task, err := s.taskRepo.FindByTaskRef(ctx, req.TaskRef)
+	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskRef, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if task == nil {

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -105,6 +105,24 @@ func (m *mongoTaskRepo) FindByTaskRef(ctx context.Context, taskRef string) (*mod
 	return task, nil
 }
 
+func (m *mongoTaskRepo) FindByTaskRefAndProjectID(ctx context.Context, taskRef string, projectID bson.ObjectID) (*models.Task, error) {
+	task := new(models.Task)
+
+	f := NewTaskFilter()
+	f.WithTaskRef(taskRef)
+	f.WithProjectID(projectID)
+
+	err := m.collection.FindOne(ctx, f).Decode(task)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return task, nil
+}
+
 func (m *mongoTaskRepo) UpdateDetail(ctx context.Context, in *repositories.UpdateTaskDetailRequest) (*models.Task, error) {
 	f := NewTaskFilter()
 	f.WithID(in.ID)

--- a/internal/infrastructure/router/api_router.go
+++ b/internal/infrastructure/router/api_router.go
@@ -67,13 +67,13 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 		projects.PUT("/:projectId/members/position", r.projectMember.UpdatePosition, r.authMiddleware.Middleware)
 	}
 
-	tasks := api.Group("/tasks/v1")
+	tasks := api.Group("/projects/v1/:projectId/tasks/v1")
 	{
 		tasks.POST("", r.task.Create, r.authMiddleware.Middleware)
 		tasks.GET("/:taskRef", r.task.GetTaskDetail, r.authMiddleware.Middleware)
 
-		tasks.GET("/projects/:projectId/epic", r.task.ListEpicTasks, r.authMiddleware.Middleware)
-		tasks.GET("/projects/:projectId", r.task.SearchTask, r.authMiddleware.Middleware)
+		tasks.GET("/epic", r.task.ListEpicTasks, r.authMiddleware.Middleware)
+		tasks.GET("", r.task.SearchTask, r.authMiddleware.Middleware)
 
 		tasks.PUT("/:taskRef/detail", r.task.UpdateDetail, r.authMiddleware.Middleware)
 		tasks.PUT("/:taskRef/status", r.task.UpdateStatus, r.authMiddleware.Middleware)


### PR DESCRIPTION
This pull request introduces several changes to the task management system, focusing on enhancing task retrieval and update operations by including project ID as a parameter. The changes span across multiple files, ensuring that tasks are correctly associated with their respective projects.

### Task Retrieval and Update Enhancements:

* Added a new method `FindByTaskRefAndProjectID` to the `TaskRepository` interface to allow finding tasks by both task reference and project ID. (`domain/repositories/task_repo.go`)
* Implemented the `FindByTaskRefAndProjectID` method in the MongoDB task repository. (`internal/adapters/repositories/mongo/mongo_task_repo.go`)

### Request Struct Updates:

* Updated various request structs to include `ProjectID` as a required parameter. This includes `CreateTaskRequest`, `UpdateTaskDetailRequest`, `UpdateTaskStatusRequest`, `UpdateTaskApprovalsRequest`, `ApproveTaskRequest`, `UpdateTaskAssigneesRequest`, `UpdateTaskSprintRequest`, and `UpdateTaskAttributesRequest`. (`domain/requests/task_request.go`) [[1]](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfL3-R20) [[2]](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfL28-R36) [[3]](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfR47-R91)

### Service Layer Modifications:

* Modified service methods to convert `ProjectID` from string to `bson.ObjectID` and use the new repository method `FindByTaskRefAndProjectID` for task retrieval. This affects methods such as `GetTaskDetail`, `UpdateDetail`, `UpdateStatus`, `UpdateApprovals`, `ApproveTask`, `UpdateAssignees`, `UpdateSprint`, and `UpdateAttributes`. (`domain/services/task_service.go`) [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL206-R211) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR484-R494) [[3]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL696-R711) [[4]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL744-R764) [[5]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL788-R813) [[6]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL822-R852) [[7]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL968-R1003) [[8]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1020-R1060)

### API Route Adjustments:

* Adjusted the API routes to include `projectId` in the task routes, ensuring that task operations are scoped to specific projects. (`internal/infrastructure/router/api_router.go`)