### PR TITLE
fix: check if no project is found case.

### DIFF
--- a/domain/services/sprint_service.go
+++ b/domain/services/sprint_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/cnc-csku/task-nexus-go-lib/utils/errutils"
+	"github.com/cnc-csku/task-nexus/task-management/domain/exceptions"
 	"github.com/cnc-csku/task-nexus/task-management/domain/models"
 	"github.com/cnc-csku/task-nexus/task-management/domain/repositories"
 	"github.com/cnc-csku/task-nexus/task-management/domain/requests"
@@ -37,18 +38,18 @@ func NewSprintService(
 func (s *sprintServiceImpl) Create(ctx context.Context, req *requests.CreateSprintRequest, userID string) (*responses.CreateSprintResponse, *errutils.Error) {
 	bsonUserID, err := bson.ObjectIDFromHex(userID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
 	project, err := s.projectRepo.FindByProjectID(ctx, bsonProjectID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if project == nil {
-		return nil, errutils.NewError(fmt.Errorf("project not found"), errutils.NotFound).WithDebugMessage("project not found")
+		return nil, errutils.NewError(exceptions.ErrProjectNotFound, errutils.BadRequest).WithDebugMessage("project not found")
 	}
 
 	// should be in transaction, to be implemented
@@ -60,12 +61,12 @@ func (s *sprintServiceImpl) Create(ctx context.Context, req *requests.CreateSpri
 
 	createdSprint, err := s.sprintRepo.Create(ctx, sprint)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
 	err = s.projectRepo.IncrementSprintRunningNumber(ctx, bsonProjectID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
 	return &responses.CreateSprintResponse{
@@ -80,14 +81,14 @@ func (s *sprintServiceImpl) Create(ctx context.Context, req *requests.CreateSpri
 func (s *sprintServiceImpl) GetByID(ctx context.Context, req *requests.GetSprintByIDRequest) (*models.Sprint, *errutils.Error) {
 	bsonSprintID, err := bson.ObjectIDFromHex(req.SprintID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
 	sprint, err := s.sprintRepo.FindByID(ctx, bsonSprintID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	} else if sprint == nil {
-		return nil, errutils.NewError(fmt.Errorf("sprint not found"), errutils.NotFound).WithDebugMessage("sprint not found")
+		return nil, errutils.NewError(exceptions.ErrSprintNotFound, errutils.NotFound).WithDebugMessage("sprint not found")
 	}
 
 	return sprint, nil
@@ -96,11 +97,18 @@ func (s *sprintServiceImpl) GetByID(ctx context.Context, req *requests.GetSprint
 func (s *sprintServiceImpl) Edit(ctx context.Context, req *requests.EditSprintRequest, userID string) (*responses.EditSprintResponse, *errutils.Error) {
 	bsonUserID, err := bson.ObjectIDFromHex(userID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 	bsonSprintID, err := bson.ObjectIDFromHex(req.SprintID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	sprint, err := s.sprintRepo.FindByID(ctx, bsonSprintID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if sprint == nil {
+		return nil, errutils.NewError(exceptions.ErrSprintNotFound, errutils.NotFound).WithDebugMessage("sprint not found")
 	}
 
 	var (
@@ -109,7 +117,7 @@ func (s *sprintServiceImpl) Edit(ctx context.Context, req *requests.EditSprintRe
 	)
 	if req.Duration != nil {
 		if req.StartDate == nil {
-			return nil, errutils.NewError(fmt.Errorf("start date is required when duration is provided"), errutils.BadRequest).WithDebugMessage("start date is required when duration is provided")
+			return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage("start date is required")
 		}
 		computedEndDate := req.StartDate.AddDate(0, 0, int(*req.Duration))
 		endDate = &computedEndDate
@@ -126,7 +134,7 @@ func (s *sprintServiceImpl) Edit(ctx context.Context, req *requests.EditSprintRe
 
 	err = s.sprintRepo.Update(ctx, sprintUpdateRequest)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
 	return &responses.EditSprintResponse{
@@ -137,12 +145,19 @@ func (s *sprintServiceImpl) Edit(ctx context.Context, req *requests.EditSprintRe
 func (s *sprintServiceImpl) ListByProjectID(ctx context.Context, req *requests.ListSprintByProjectIDPathParam) ([]models.Sprint, *errutils.Error) {
 	bsonProjectID, err := bson.ObjectIDFromHex(req.ProjectID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.BadRequest).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
+	}
+
+	project, err := s.projectRepo.FindByProjectID(ctx, bsonProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if project == nil {
+		return nil, errutils.NewError(exceptions.ErrProjectNotFound, errutils.BadRequest).WithDebugMessage("project not found")
 	}
 
 	sprints, err := s.sprintRepo.FindByProjectID(ctx, bsonProjectID)
 	if err != nil {
-		return nil, errutils.NewError(err, errutils.InternalServerError).WithDebugMessage(err.Error())
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
 	return sprints, nil

--- a/domain/services/sprint_service.go
+++ b/domain/services/sprint_service.go
@@ -55,7 +55,7 @@ func (s *sprintServiceImpl) Create(ctx context.Context, req *requests.CreateSpri
 	// should be in transaction, to be implemented
 	sprint := &repositories.CreateSprintRequest{
 		ProjectID: bsonProjectID,
-		Title:     fmt.Sprintf("Sprint %d", project.SprintRunningNumber),
+		Title:     fmt.Sprintf("%s Sprint %d", project.Name, project.SprintRunningNumber),
 		CreatedBy: bsonUserID,
 	}
 


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `sprint_service.go` file by using predefined exceptions from the `exceptions` package. The changes replace generic error messages with more specific, predefined error constants.

Error handling improvements:

* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fR8): Added import for `exceptions` package to use predefined error constants.
* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL40-R52): Replaced generic errors with `exceptions.ErrInternalError` and other specific error constants in the `Create` method. [[1]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL40-R52) [[2]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL63-R69)
* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL83-R91): Updated error handling in the `GetByID` method to use `exceptions.ErrInternalError` and `exceptions.ErrSprintNotFound`.
* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL99-R111): Enhanced error handling in the `Edit` method by using `exceptions.ErrInternalError` and `exceptions.ErrSprintNotFound`. [[1]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL99-R111) [[2]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL112-R120) [[3]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL129-R137)
* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL140-R160): Improved error handling in the `ListByProjectID` method by using `exceptions.ErrInternalError` and `exceptions.ErrProjectNotFound`.