### PR TITLE
fix: change SprintGoal field from pointer to value in sprint models and requests

### DIFF
--- a/domain/models/sprint.go
+++ b/domain/models/sprint.go
@@ -10,7 +10,7 @@ type Sprint struct {
 	ID         bson.ObjectID `bson:"_id" json:"id"`
 	ProjectID  bson.ObjectID `bson:"project_id" json:"projectId"`
 	Title      string        `bson:"title" json:"title"`
-	SprintGoal *string       `bson:"sprint_goal" json:"sprintGoal"`
+	SprintGoal string        `bson:"sprint_goal" json:"sprintGoal"`
 	StartDate  *time.Time    `bson:"start_date" json:"startDate"`
 	EndDate    *time.Time    `bson:"end_date" json:"endDate"`
 	CreatedAt  time.Time     `bson:"created_at" json:"createdAt"`

--- a/domain/repositories/sprint_repo.go
+++ b/domain/repositories/sprint_repo.go
@@ -24,7 +24,7 @@ type CreateSprintRequest struct {
 type UpdateSprintRequest struct {
 	ID         bson.ObjectID
 	Title      string
-	SprintGoal *string
+	SprintGoal string
 	StartDate  *time.Time
 	EndDate    *time.Time
 	UpdatedBy  bson.ObjectID

--- a/domain/requests/sprint_request.go
+++ b/domain/requests/sprint_request.go
@@ -14,7 +14,7 @@ type EditSprintRequest struct {
 	ProjectID  string     `param:"projectId" validate:"required"`
 	SprintID   string     `param:"sprintId" validate:"required"`
 	Title      string     `json:"title" validate:"required"`
-	SprintGoal *string    `json:"sprintGoal"`
+	SprintGoal string     `json:"sprintGoal"`
 	Duration   *int       `json:"duration"`
 	StartDate  *time.Time `json:"startDate"`
 	EndDate    *time.Time `json:"endDate"`


### PR DESCRIPTION
This pull request includes changes to the `SprintGoal` field in multiple files to ensure it is always a string instead of a pointer to a string. This change will simplify the handling of `SprintGoal` throughout the codebase.

Key changes:

* [`domain/models/sprint.go`](diffhunk://#diff-2b1460df7f1ee41eb2dff41ac9360b0a564b8e9cc1c16e2febc09741440aced9L13-R13): Changed the `SprintGoal` field in the `Sprint` struct from `*string` to `string`.
* [`domain/repositories/sprint_repo.go`](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1L27-R27): Updated the `SprintGoal` field in the `CreateSprintRequest` struct from `*string` to `string`.
* [`domain/requests/sprint_request.go`](diffhunk://#diff-bf78e9bc23448f261ec92ec17fd8c9c09187bda6327777806e0de2732728ef9bL17-R17): Modified the `SprintGoal` field in the `EditSprintRequest` struct from `*string` to `string`.