### PR TITLE
feat: add support for searching tasks without a sprint

### DIFF
--- a/domain/constant/enum.go
+++ b/domain/constant/enum.go
@@ -27,6 +27,7 @@ const (
 )
 
 const (
+	SearchTaskParamsTaskBacklog          = "BACKLOG" // WITH_NO_SPRINT
 	SearchTaskParamsTaskWithNoEpicFilter = "WITH_NO_EPIC"
 )
 

--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -117,16 +117,17 @@ type UpdateTaskChildrenPointRequest struct {
 }
 
 type SearchTaskRequest struct {
-	ProjectID        bson.ObjectID
-	TaskTypes        []models.TaskType
-	SprintID         *bson.ObjectID
-	EpicTaskID       *bson.ObjectID
-	IsTaskWithNoEpic bool
-	UserIDs          []bson.ObjectID
-	Positions        []string
-	Statuses         []string
-	IsDoneStatuses   []string
-	SearchKeyword    *string
+	ProjectID          bson.ObjectID
+	TaskTypes          []models.TaskType
+	SprintID           *bson.ObjectID
+	IsTaskWithNoSprint bool
+	EpicTaskID         *bson.ObjectID
+	IsTaskWithNoEpic   bool
+	UserIDs            []bson.ObjectID
+	Positions          []string
+	Statuses           []string
+	IsDoneStatuses     []string
+	SearchKeyword      *string
 }
 
 type UpdateTaskAttributesRequest struct {

--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -24,7 +24,7 @@ type ListEpicTasksPathParam struct {
 
 type SearchTaskParams struct {
 	ProjectID     string   `param:"projectId" validate:"required"`
-	SprintID      *string  `query:"sprintId"`
+	SprintID      *string  `query:"sprintId"`   // Sprint_id or BACKLOG (WITH_NO_SPRINT)
 	EpicTaskID    *string  `query:"epicTaskId"` // Parent_id or WITH_NO_EPIC
 	UserIDs       []string `query:"userIds"`
 	Positions     []string `query:"positions"`

--- a/internal/adapters/repositories/mongo/mongo_task_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_task_bson.go
@@ -72,6 +72,12 @@ func (f taskFilter) WithSprintID(sprintID bson.ObjectID) {
 	f["sprint.current_sprint_id"] = sprintID
 }
 
+func (f taskFilter) WithNoSprintID() {
+	f["sprint.current_sprint_id"] = bson.M{
+		"$eq": nil,
+	}
+}
+
 func (f taskFilter) WithUserIDs(userIDs []bson.ObjectID) {
 	f["assignees.user_id"] = bson.M{
 		"$in": userIDs,

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -344,6 +344,10 @@ func (m *mongoTaskRepo) Search(ctx context.Context, in *repositories.SearchTaskR
 		f.WithSprintID(*in.SprintID)
 	}
 
+	if in.IsTaskWithNoSprint {
+		f.WithNoSprintID()
+	}
+
 	if in.EpicTaskID != nil {
 		f.WithParentID(*in.EpicTaskID)
 	}


### PR DESCRIPTION
This pull request introduces enhancements to the task search functionality by adding support for filtering tasks that are not associated with any sprint. The key changes include updates to the task search parameters, request handling, and repository filtering logic.

### Enhancements to task search functionality:

* [`domain/constant/enum.go`](diffhunk://#diff-4c7510e287da0bd178b843ea2fd118e5c7c65617c67fafc488b278b1da7e49a9R30): Added a new constant `SearchTaskParamsTaskBacklog` to represent tasks with no sprint.
* [`domain/repositories/task_repo.go`](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR123): Updated the `SearchTaskRequest` struct to include a new boolean field `IsTaskWithNoSprint` for filtering tasks without a sprint.
* [`domain/requests/task_request.go`](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfL27-R27): Modified the `SearchTaskParams` struct to document that `SprintID` can now also represent tasks with no sprint using the `BACKLOG` value.

### Request handling improvements:

* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL353-R367): Enhanced the `SearchTask` method to handle the new `IsTaskWithNoSprint` parameter and set it based on the `SprintID` value. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL353-R367) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR421)

### Repository filtering logic:

* [`internal/adapters/repositories/mongo/mongo_task_bson.go`](diffhunk://#diff-a11be1fb39f9e88ef778200b38f91c510127825f79edfa1a37ec039bdcd9d255R75-R80): Added a new method `WithNoSprintID` to the `taskFilter` type for filtering tasks with no sprint.
* [`internal/adapters/repositories/mongo/mongo_task_repo.go`](diffhunk://#diff-52271912ff49328dc08bd27d0d6209b669b3e89d928ad4ead0b44900da5718c3R347-R350): Updated the `Search` method to apply the new `WithNoSprintID` filter when `IsTaskWithNoSprint` is true.