### PR TITLE
feat: add startDate and dueDate to create task request.

### DIFF
--- a/domain/exceptions/task_exception.go
+++ b/domain/exceptions/task_exception.go
@@ -12,4 +12,5 @@ var (
 	ErrInvalidSearchTasksSearchFilterBy = errors.New("invalid search tasks search filter by")
 	ErrInvalidAttributeKey              = errors.New("invalid attribute key")
 	ErrNotAllTasksIsDone                = errors.New("not all tasks is done")
+	ErrDueDateBeforeStartDate           = errors.New("due date before start date")
 )

--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -41,6 +41,8 @@ type CreateTaskRequest struct {
 	Type        models.TaskType
 	Status      string
 	Sprint      *models.TaskSprint
+	StartDate   *time.Time
+	DueDate     *time.Time
 	CreatedBy   bson.ObjectID
 }
 

--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -5,12 +5,14 @@ import (
 )
 
 type CreateTaskRequest struct {
-	ProjectID   string  `param:"projectId" validate:"required"`
-	Title       string  `json:"title" validate:"required"`
-	Description string  `json:"description"`
-	ParentID    *string `json:"parentId"`
-	Type        string  `json:"type" validate:"required"`
-	SprintID    *string `json:"sprintId"`
+	ProjectID   string     `param:"projectId" validate:"required"`
+	Title       string     `json:"title" validate:"required"`
+	Description string     `json:"description"`
+	ParentID    *string    `json:"parentId"`
+	Type        string     `json:"type" validate:"required"`
+	SprintID    *string    `json:"sprintId"`
+	StartDate   *time.Time `json:"startDate"`
+	DueDate     *time.Time `json:"dueDate"`
 }
 
 type GetTaskDetailPathParam struct {

--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -72,6 +72,12 @@ func (s *taskServiceImpl) Create(ctx context.Context, req *requests.CreateTaskRe
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
+	if req.DueDate != nil && req.StartDate != nil {
+		if req.DueDate.Before(*req.StartDate) {
+			return nil, errutils.NewError(exceptions.ErrDueDateBeforeStartDate, errutils.BadRequest).WithDebugMessage("Due date is before start date")
+		}
+	}
+
 	project, err := s.projectRepo.FindByProjectID(ctx, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
@@ -163,6 +169,8 @@ func (s *taskServiceImpl) Create(ctx context.Context, req *requests.CreateTaskRe
 		Type:        models.TaskType(req.Type),
 		Status:      defaultWorkflow.Status,
 		Sprint:      taskSprint,
+		StartDate:   req.StartDate,
+		DueDate:     req.DueDate,
 		CreatedBy:   bsonUserID,
 	})
 	if err != nil {

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -38,6 +38,8 @@ func (m *mongoTaskRepo) Create(ctx context.Context, task *repositories.CreateTas
 		Status:      task.Status,
 		Priority:    models.TaskPriorityMedium,
 		Sprint:      task.Sprint,
+		StartDate:   task.StartDate,
+		DueDate:     task.DueDate,
 		CreatedAt:   time.Now(),
 		CreatedBy:   task.CreatedBy,
 		UpdatedAt:   time.Now(),


### PR DESCRIPTION
This pull request introduces changes to support start and due dates for tasks. The most important changes include adding new fields for `StartDate` and `DueDate` in task-related structures and ensuring the due date is not before the start date.

### Enhancements to task management:

* [`domain/exceptions/task_exception.go`](diffhunk://#diff-e2d0eba2f8c5029bce71ba3a2e2e2575b51365af3ced433c761fbe034d4b6bcaR15): Added a new error `ErrDueDateBeforeStartDate` to handle the case when the due date is before the start date.
* [`domain/repositories/task_repo.go`](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR44-R45): Added `StartDate` and `DueDate` fields to the `CreateTaskRequest` struct.
* [`domain/requests/task_request.go`](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfR14-R15): Added `StartDate` and `DueDate` fields to the `CreateTaskRequest` struct.

### Validation and storage:

* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR75-R80): Added validation to ensure the due date is not before the start date in the `Create` method, and included the new fields in task creation. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR75-R80) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR172-R173)
* [`internal/adapters/repositories/mongo/mongo_task_repo.go`](diffhunk://#diff-52271912ff49328dc08bd27d0d6209b669b3e89d928ad4ead0b44900da5718c3R41-R42): Included `StartDate` and `DueDate` fields in the task creation logic for MongoDB storage.