### PR TITLE
feat: add status field to Sprint model and update related requests and services

### DIFF
--- a/domain/models/sprint.go
+++ b/domain/models/sprint.go
@@ -11,13 +11,13 @@ type Sprint struct {
 	ProjectID  bson.ObjectID `bson:"project_id" json:"projectId"`
 	Title      string        `bson:"title" json:"title"`
 	SprintGoal string        `bson:"sprint_goal" json:"sprintGoal"`
-	// Status
-	StartDate *time.Time    `bson:"start_date" json:"startDate"`
-	EndDate   *time.Time    `bson:"end_date" json:"endDate"`
-	CreatedAt time.Time     `bson:"created_at" json:"createdAt"`
-	CreatedBy bson.ObjectID `bson:"created_by" json:"createdBy"`
-	UpdatedAt time.Time     `bson:"updated_at" json:"updatedAt"`
-	UpdatedBy bson.ObjectID `bson:"updated_by" json:"updatedBy"`
+	Status     SprintStatus  `bson:"status" json:"status"`
+	StartDate  *time.Time    `bson:"start_date" json:"startDate"`
+	EndDate    *time.Time    `bson:"end_date" json:"endDate"`
+	CreatedAt  time.Time     `bson:"created_at" json:"createdAt"`
+	CreatedBy  bson.ObjectID `bson:"created_by" json:"createdBy"`
+	UpdatedAt  time.Time     `bson:"updated_at" json:"updatedAt"`
+	UpdatedBy  bson.ObjectID `bson:"updated_by" json:"updatedBy"`
 }
 
 type SprintStatus string

--- a/domain/repositories/sprint_repo.go
+++ b/domain/repositories/sprint_repo.go
@@ -21,6 +21,7 @@ type SprintRepository interface {
 type CreateSprintRequest struct {
 	ProjectID bson.ObjectID
 	Title     string
+	Status    models.SprintStatus
 	CreatedBy bson.ObjectID
 }
 
@@ -36,6 +37,7 @@ type UpdateSprintRequest struct {
 type ListSprintFilter struct {
 	ProjectID bson.ObjectID
 	IsActive  *bool
+	Status    *models.SprintStatus
 }
 
 type UpdateSprintStatusRequest struct {

--- a/domain/requests/sprint_request.go
+++ b/domain/requests/sprint_request.go
@@ -7,7 +7,8 @@ type CreateSprintRequest struct {
 }
 
 type GetSprintByIDRequest struct {
-	SprintID string `param:"sprintId" validate:"required"`
+	ProjectID string `param:"projectId" validate:"required"`
+	SprintID  string `param:"sprintId" validate:"required"`
 }
 
 type EditSprintRequest struct {
@@ -21,8 +22,9 @@ type EditSprintRequest struct {
 }
 
 type ListSprintPathParam struct {
-	ProjectID string `param:"projectId" validate:"required"`
-	IsActive  *bool  `query:"isActive"`
+	ProjectID string  `param:"projectId" validate:"required"`
+	IsActive  *bool   `query:"isActive"`
+	Status    *string `query:"status"`
 }
 
 type CompleteSprintRequest struct {

--- a/domain/responses/sprint_response.go
+++ b/domain/responses/sprint_response.go
@@ -6,6 +6,7 @@ type CreateSprintResponse struct {
 	ID        string    `json:"id"`
 	ProjectID string    `json:"projectId"`
 	Title     string    `json:"title"`
+	Status    string    `json:"status"`
 	CreatedAt time.Time `json:"createdAt"`
 	CreatedBy string    `json:"createdBy"`
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.5-20250219170025-d39267d9df8f.1
 	github.com/caarlos0/env/v11 v11.3.1
-	github.com/cnc-csku/task-nexus-go-lib v1.2.0
+	github.com/cnc-csku/task-nexus-go-lib v1.3.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/generative-ai-go v0.19.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cnc-csku/task-nexus-api-specification v0.0.0-20250221084027-937f1dec107a h1:cj7FtPhIW9VJIOOiBkdt4EDkhRzjf6nk973VaMpVzsQ=
 github.com/cnc-csku/task-nexus-api-specification v0.0.0-20250221084027-937f1dec107a/go.mod h1:4cceRs12rhYVFfwGj7OPMg2CJb/g0J9oC97lrcLSiV0=
-github.com/cnc-csku/task-nexus-go-lib v1.2.0 h1:PXvRt8ZswLCdGPWQP97OPnUTz6CPMksXzTA38JbQQQg=
-github.com/cnc-csku/task-nexus-go-lib v1.2.0/go.mod h1:P1seoHHHP99/LifTBhEG0sKjYyBfKIELPqxn4Puc7mQ=
+github.com/cnc-csku/task-nexus-go-lib v1.3.0 h1:+OXhR0r9+B72EtDiQWq6RdOj2+TZNH7EtVE62y0PPMU=
+github.com/cnc-csku/task-nexus-go-lib v1.3.0/go.mod h1:Wze/L1KN/jkC8BMfZHFvX6ooYbmQe9o5RTykBlE94ZQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/adapters/repositories/mongo/mongo_sprint_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_sprint_bson.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"time"
 
+	"github.com/cnc-csku/task-nexus/task-management/domain/models"
 	"github.com/cnc-csku/task-nexus/task-management/domain/repositories"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -26,6 +27,10 @@ func (f sprintFilter) WithEndDateGreaterThanOrEqualNowOrIsNull() {
 		{"end_date": bson.M{"$gte": time.Now()}},
 		{"end_date": bson.M{"$eq": nil}},
 	}
+}
+
+func (f sprintFilter) WithStatus(status models.SprintStatus) {
+	f["status"] = status
 }
 
 type sprintUpdater bson.M

--- a/internal/adapters/repositories/mongo/mongo_sprint_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_sprint_repo.go
@@ -29,6 +29,7 @@ func (m *mongoSprintRepo) Create(ctx context.Context, sprint *repositories.Creat
 		ID:        bson.NewObjectID(),
 		ProjectID: sprint.ProjectID,
 		Title:     sprint.Title,
+		Status:    sprint.Status,
 		CreatedAt: time.Now(),
 		CreatedBy: sprint.CreatedBy,
 		UpdatedAt: time.Now(),
@@ -116,6 +117,10 @@ func (m *mongoSprintRepo) List(ctx context.Context, filter *repositories.ListSpr
 
 	if filter.IsActive != nil && *filter.IsActive {
 		f.WithEndDateGreaterThanOrEqualNowOrIsNull()
+	}
+
+	if filter.Status != nil {
+		f.WithStatus(*filter.Status)
 	}
 
 	cursor, err := m.collection.Find(ctx, f)

--- a/internal/adapters/rest/sprint_handler.go
+++ b/internal/adapters/rest/sprint_handler.go
@@ -60,7 +60,8 @@ func (h *sprintHandlerImpl) GetByID(c echo.Context) error {
 		return err
 	}
 
-	sprint, err := h.sprintService.GetByID(c.Request().Context(), req)
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+	sprint, err := h.sprintService.GetByID(c.Request().Context(), req, userClaims.ID)
 	if err != nil {
 		return err.ToEchoError()
 	}
@@ -97,7 +98,8 @@ func (h *sprintHandlerImpl) List(c echo.Context) error {
 		return err
 	}
 
-	sprints, err := h.sprintService.List(c.Request().Context(), req)
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+	sprints, err := h.sprintService.List(c.Request().Context(), req, userClaims.ID)
 	if err != nil {
 		return err.ToEchoError()
 	}


### PR DESCRIPTION
This pull request includes several changes to enhance the sprint management functionality. The primary updates involve adding a `Status` field to various sprint-related structures and methods, and ensuring user authorization for accessing sprint data.

Enhancements to sprint management:

* [`domain/models/sprint.go`](diffhunk://#diff-2b1460df7f1ee41eb2dff41ac9360b0a564b8e9cc1c16e2febc09741440aced9L14-R14): Added `Status` field to the `Sprint` struct to track the status of sprints.
* [`domain/repositories/sprint_repo.go`](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1R24): Added `Status` field to `CreateSprintRequest` and `ListSprintFilter` structs to support status tracking in repository operations. [[1]](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1R24) [[2]](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1R40)
* [`domain/requests/sprint_request.go`](diffhunk://#diff-bf78e9bc23448f261ec92ec17fd8c9c09187bda6327777806e0de2732728ef9bR10): Added `Status` field to `GetSprintByIDRequest` and `ListSprintPathParam` structs to include status in API requests. [[1]](diffhunk://#diff-bf78e9bc23448f261ec92ec17fd8c9c09187bda6327777806e0de2732728ef9bR10) [[2]](diffhunk://#diff-bf78e9bc23448f261ec92ec17fd8c9c09187bda6327777806e0de2732728ef9bR27)
* [`domain/responses/sprint_response.go`](diffhunk://#diff-4ed9ce5a1c663d53271405fc468242cfdc7cc3b32a185f1f86571f34b7a398c5R9): Added `Status` field to `CreateSprintResponse` struct to include status in API responses.

User authorization improvements:

* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL19-R21): Updated `GetByID` and `List` methods to include user ID for authorization checks, ensuring that only project members can access sprint data. [[1]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL19-R21) [[2]](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL155-R211)
* [`internal/adapters/rest/sprint_handler.go`](diffhunk://#diff-eaa387f4296cc3b18aceff90855e773ec453f7a2b0bce59ad533d311459d0e20L63-R64): Modified `GetByID` and `List` handlers to pass user ID to service methods for authorization. [[1]](diffhunk://#diff-eaa387f4296cc3b18aceff90855e773ec453f7a2b0bce59ad533d311459d0e20L63-R64) [[2]](diffhunk://#diff-eaa387f4296cc3b18aceff90855e773ec453f7a2b0bce59ad533d311459d0e20L100-R102)