### PR TITLE
feat: handle nil values in additional fields for task creation

### DIFF
--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -185,6 +185,14 @@ func (s *taskServiceImpl) Create(ctx context.Context, req *requests.CreateTaskRe
 	attributes := make([]models.TaskAttribute, 0, len(req.AdditionalFields))
 	for key, value := range req.AdditionalFields {
 		if attribute, ok := attributeTemplates[key]; ok {
+			if value == nil {
+				attributes = append(attributes, models.TaskAttribute{
+					Key:   key,
+					Value: nil,
+				})
+				continue
+			}
+
 			var val any
 			switch attribute.Type {
 			case models.KeyValuePairTypeString:


### PR DESCRIPTION
This pull request includes a small but important change to the `Create` function in the `taskServiceImpl` class. The change ensures that `nil` values in `req.AdditionalFields` are properly handled by adding a check and appending a `TaskAttribute` with a `nil` value if necessary.

* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR188-R195): Added a check to handle `nil` values in `req.AdditionalFields` and append a corresponding `TaskAttribute` with a `nil` value.