### PR TITLE
feat: improve the logic of syncing sprint between subtask and level 1 tasks.

### DIFF
--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -35,6 +35,7 @@ type TaskRepository interface {
 	FindByCurrentSprintID(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
 	FindByPreviousSprintID(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
 	FindByCurrentSprintIDAndPreviousSprintIDs(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
+	BulkUpdateCurrentSprintID(ctx context.Context, in *BulkUpdateCurrentSprintIDRequest) error
 }
 
 type CreateTaskRequest struct {
@@ -157,4 +158,10 @@ type UpdateTaskAttributesRequest struct {
 	ID         bson.ObjectID
 	Attributes []models.TaskAttribute
 	UpdatedBy  bson.ObjectID
+}
+
+type BulkUpdateCurrentSprintIDRequest struct {
+	TaskIDs         []bson.ObjectID
+	CurrentSprintID *bson.ObjectID
+	UpdatedBy       bson.ObjectID
 }

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/redis/go-redis/v9 v9.7.0
+	github.com/redis/go-redis/v9 v9.7.3
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
-github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=

--- a/internal/adapters/repositories/mongo/mongo_task_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_task_bson.go
@@ -205,13 +205,13 @@ func (u taskUpdate) UpdateAssignees(in *repositories.UpdateTaskAssigneesRequest)
 	}
 }
 
-func (u taskUpdate) UpdateCurrentSprintID(in *repositories.UpdateTaskCurrentSprintIDRequest) {
+func (u taskUpdate) UpdateCurrentSprintID(currentSprintID *bson.ObjectID, updatedBy bson.ObjectID) {
 	u["$set"] = bson.M{
 		"sprint": bson.M{
-			"current_sprint_id": in.CurrentSprintID,
+			"current_sprint_id": currentSprintID,
 		},
 		"updated_at": time.Now(),
-		"updated_by": in.UpdatedBy,
+		"updated_by": updatedBy,
 	}
 }
 

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -273,7 +273,7 @@ func (m *mongoTaskRepo) UpdateCurrentSprintID(ctx context.Context, in *repositor
 	f.WithID(in.ID)
 
 	u := NewTaskUpdate()
-	u.UpdateCurrentSprintID(in)
+	u.UpdateCurrentSprintID(in.CurrentSprintID, in.UpdatedBy)
 
 	err := m.collection.FindOneAndUpdate(ctx, f, u).Err()
 	if err != nil {
@@ -509,4 +509,19 @@ func (m *mongoTaskRepo) FindByCurrentSprintIDAndPreviousSprintIDs(ctx context.Co
 	}
 
 	return tasks, nil
+}
+
+func (m *mongoTaskRepo) BulkUpdateCurrentSprintID(ctx context.Context, in *repositories.BulkUpdateCurrentSprintIDRequest) error {
+	f := NewTaskFilter()
+	f.WithIDs(in.TaskIDs)
+
+	u := NewTaskUpdate()
+	u.UpdateCurrentSprintID(in.CurrentSprintID, in.UpdatedBy)
+
+	_, err := m.collection.UpdateMany(ctx, f, u)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This pull request includes several changes to the task management system, focusing on updating task sprints and improving the handling of sprint IDs. The most important changes include adding bulk update functionality for task sprints, ensuring task sprints are correctly updated when parent tasks change, and updating dependencies.

### Task Sprint Updates:

* Added a new method `BulkUpdateCurrentSprintID` to the `TaskRepository` interface to support bulk updates of current sprint IDs (`domain/repositories/task_repo.go`).
* Introduced a new struct `BulkUpdateCurrentSprintIDRequest` to encapsulate the request parameters for bulk sprint ID updates (`domain/repositories/task_repo.go`).

### Task Service Enhancements:

* Modified the `Create` method to initialize `taskSprint` with an empty `TaskSprint` object (`domain/services/task_service.go`).
* Updated the `UpdateParentID` method to set the task's sprint to the parent task's sprint and to handle setting the sprint to nil when necessary (`domain/services/task_service.go`). [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR916-R925) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR980-R989)
* Enhanced the `UpdateSprint` method to update the sprints of child tasks when the sprint of a parent task is updated (`domain/services/task_service.go`).

### Repository Changes:

* Updated the `UpdateCurrentSprintID` method in `mongo_task_bson.go` to accept parameters directly instead of using a request struct (`internal/adapters/repositories/mongo/mongo_task_bson.go`).
* Added a new method `BulkUpdateCurrentSprintID` to the `mongoTaskRepo` to handle bulk updates of current sprint IDs (`internal/adapters/repositories/mongo/mongo_task_repo.go`).

### Dependency Updates:

* Updated the `go-redis` dependency to version 9.7.3 in the `go.mod` file (`go.mod`).