### PR TITLE
feat: add support for retrieving multiple task details and enhance sprint filtering by statuses

### DIFF
--- a/domain/repositories/sprint_repo.go
+++ b/domain/repositories/sprint_repo.go
@@ -16,6 +16,7 @@ type SprintRepository interface {
 	List(ctx context.Context, filter *ListSprintFilter) ([]models.Sprint, error)
 	UpdateStatus(ctx context.Context, req *UpdateSprintStatusRequest) (*models.Sprint, error)
 	Delete(ctx context.Context, sprintID bson.ObjectID) error
+	FindByProjectIDAndStatus(ctx context.Context, projectID bson.ObjectID, status models.SprintStatus) ([]models.Sprint, error)
 }
 
 type CreateSprintRequest struct {
@@ -37,7 +38,7 @@ type UpdateSprintRequest struct {
 type ListSprintFilter struct {
 	ProjectID bson.ObjectID
 	IsActive  *bool
-	Status    *models.SprintStatus
+	Statuses  []models.SprintStatus
 }
 
 type UpdateSprintStatusRequest struct {

--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -14,6 +14,7 @@ type TaskRepository interface {
 	FindByIDs(ctx context.Context, ids []bson.ObjectID) ([]*models.Task, error)
 	FindByTaskRef(ctx context.Context, taskRef string) (*models.Task, error)
 	FindByTaskRefAndProjectID(ctx context.Context, taskRef string, projectID bson.ObjectID) (*models.Task, error)
+	FindByTaskRefsAndProjectID(ctx context.Context, taskRefs []string, projectID bson.ObjectID) ([]*models.Task, error)
 	FindByProjectID(ctx context.Context, projectID bson.ObjectID) ([]*models.Task, error)
 	UpdateDetail(ctx context.Context, in *UpdateTaskDetailRequest) (*models.Task, error)
 	UpdateTitle(ctx context.Context, in *UpdateTaskTitleRequest) (*models.Task, error)
@@ -36,6 +37,7 @@ type TaskRepository interface {
 	FindByPreviousSprintID(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
 	FindByCurrentSprintIDAndPreviousSprintIDs(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
 	BulkUpdateCurrentSprintID(ctx context.Context, in *BulkUpdateCurrentSprintIDRequest) error
+	FindByCurrentSprintIDs(ctx context.Context, sprintIDs []bson.ObjectID) ([]*models.Task, error)
 }
 
 type CreateTaskRequest struct {

--- a/domain/requests/report_request.go
+++ b/domain/requests/report_request.go
@@ -12,10 +12,11 @@ type GetTaskTypeOverviewRequest struct {
 	ProjectID string `param:"projectId" validate:"required"`
 }
 
-type GetTaskAssigneeOverviewRequest struct {
+type GetEpicTaskOverviewRequest struct {
 	ProjectID string `param:"projectId" validate:"required"`
 }
 
-type GetEpicTaskOverviewRequest struct {
-	ProjectID string `param:"projectId" validate:"required"`
+type GetTaskAssigneeOverviewBySprintRequest struct {
+	ProjectID    string `param:"projectId" validate:"required"`
+	GetAllSprint *bool  `query:"getAllSprint"` // Default: Get Active Sprint
 }

--- a/domain/requests/sprint_request.go
+++ b/domain/requests/sprint_request.go
@@ -22,9 +22,9 @@ type EditSprintRequest struct {
 }
 
 type ListSprintPathParam struct {
-	ProjectID string  `param:"projectId" validate:"required"`
-	IsActive  *bool   `query:"isActive"`
-	Status    *string `query:"status"`
+	ProjectID string   `param:"projectId" validate:"required"`
+	IsActive  *bool    `query:"isActive"`
+	Statuses  []string `query:"statuses"`
 }
 
 type CompleteSprintRequest struct {

--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -30,6 +30,11 @@ type GetTaskDetailPathParam struct {
 	TaskRef   string `param:"taskRef" validate:"required"`
 }
 
+type GetManyTaskDetailPathParam struct {
+	ProjectID string   `param:"projectId" validate:"required"`
+	TaskRefs  []string `query:"taskRefs" validate:"required"`
+}
+
 type ListEpicTasksPathParam struct {
 	ProjectID string `param:"projectId" validate:"required"`
 }

--- a/domain/responses/report_response.go
+++ b/domain/responses/report_response.go
@@ -33,20 +33,6 @@ type GetTaskTypeOverviewResponseTypes struct {
 	Percent float64 `json:"percent"`
 }
 
-type GetTaskAssigneeOverviewResponse struct {
-	Assignees  []GetTaskAssigneeOverviewResponseAssignees `json:"assignees"`
-	TotalCount int                                        `json:"totalCount"`
-}
-
-type GetTaskAssigneeOverviewResponseAssignees struct {
-	UserID      string  `json:"userID"`
-	FullName    string  `json:"fullName"`
-	DisplayName string  `json:"displayName"`
-	ProfileUrl  string  `json:"profileUrl"`
-	Count       int     `json:"count"`
-	Percent     float64 `json:"percent"`
-}
-
 type GetEpicTaskOverviewResponse struct {
 	Epics      []GetEpicTaskOverviewResponseEpics `json:"epics"`
 	TotalCount int                                `json:"totalCount"`
@@ -64,4 +50,28 @@ type GetEpicTaskOverviewResponseEpicsStatuses struct {
 	Status  string  `json:"status"`
 	Count   int     `json:"count"`
 	Percent float64 `json:"percent"`
+}
+
+type GetAssigneeOverviewBySprintResponse struct {
+	Sprints    []GetAssigneeOverviewBySprintResponseSprint `json:"sprints"`
+	TotalCount int                                         `json:"totalCount"`
+}
+
+type GetAssigneeOverviewBySprintResponseSprint struct {
+	SprintID    string                                              `json:"sprintID"`
+	SprintTitle string                                              `json:"sprintTitle"`
+	Assignees   []GetAssigneeOverviewBySprintResponseSprintAssignee `json:"assignees"`
+	TotalTask   int                                                 `json:"totalTask"`
+	TotalPoint  int                                                 `json:"totalPoint"`
+}
+
+type GetAssigneeOverviewBySprintResponseSprintAssignee struct {
+	UserID       string  `json:"userID"`
+	FullName     string  `json:"fullName"`
+	DisplayName  string  `json:"displayName"`
+	ProfileUrl   string  `json:"profileUrl"`
+	TaskCount    int     `json:"taskCount"`
+	PointCount   int     `json:"pointCount"`
+	TaskPercent  float64 `json:"taskPercent"`
+	PointPercent float64 `json:"pointPercent"`
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/cnc-csku/task-nexus-go-lib v1.3.0
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/generative-ai-go v0.19.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL
 github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/internal/adapters/repositories/mongo/mongo_sprint_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_sprint_bson.go
@@ -33,6 +33,12 @@ func (f sprintFilter) WithStatus(status models.SprintStatus) {
 	f["status"] = status
 }
 
+func (f sprintFilter) WithStatuses(statuses []models.SprintStatus) {
+	f["status"] = bson.M{
+		"$in": statuses,
+	}
+}
+
 type sprintUpdater bson.M
 
 func NewSprintUpdater() sprintUpdater {

--- a/internal/adapters/repositories/mongo/mongo_sprint_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_sprint_repo.go
@@ -119,8 +119,8 @@ func (m *mongoSprintRepo) List(ctx context.Context, filter *repositories.ListSpr
 		f.WithEndDateGreaterThanOrEqualNowOrIsNull()
 	}
 
-	if filter.Status != nil {
-		f.WithStatus(*filter.Status)
+	if filter.Statuses != nil {
+		f.WithStatuses(filter.Statuses)
 	}
 
 	cursor, err := m.collection.Find(ctx, f)
@@ -167,4 +167,25 @@ func (m *mongoSprintRepo) Delete(ctx context.Context, sprintID bson.ObjectID) er
 	}
 
 	return nil
+}
+
+func (m *mongoSprintRepo) FindByProjectIDAndStatus(ctx context.Context, projectID bson.ObjectID, status models.SprintStatus) ([]models.Sprint, error) {
+	sprints := make([]models.Sprint, 0)
+
+	f := NewSprintFilter()
+	f.WithProjectID(projectID)
+	f.WithStatus(status)
+
+	cursor, err := m.collection.Find(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	err = cursor.All(ctx, &sprints)
+	if err != nil {
+		return nil, err
+	}
+
+	return sprints, nil
 }

--- a/internal/adapters/repositories/mongo/mongo_task_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_task_bson.go
@@ -28,6 +28,12 @@ func (f taskFilter) WithTaskRef(taskRef string) {
 	f["task_ref"] = taskRef
 }
 
+func (f taskFilter) WithTaskRefs(taskRefs []string) {
+	f["task_ref"] = bson.M{
+		"$in": taskRefs,
+	}
+}
+
 func (f taskFilter) WithUserApproval(userID bson.ObjectID) {
 	f["approvals.user_id"] = userID
 }
@@ -72,9 +78,9 @@ func (f taskFilter) WithCurrentSprintID(sprintID bson.ObjectID) {
 	f["sprint.current_sprint_id"] = sprintID
 }
 
-func (f taskFilter) WithCurrentSprintIDs(sprintID []bson.ObjectID) {
+func (f taskFilter) WithCurrentSprintIDs(sprintIDs []bson.ObjectID) {
 	f["sprint.current_sprint_id"] = bson.M{
-		"$in": sprintID,
+		"$in": sprintIDs,
 	}
 }
 

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -128,6 +128,26 @@ func (m *mongoTaskRepo) FindByTaskRefAndProjectID(ctx context.Context, taskRef s
 	return task, nil
 }
 
+func (m *mongoTaskRepo) FindByTaskRefsAndProjectID(ctx context.Context, taskRefs []string, projectID bson.ObjectID) ([]*models.Task, error) {
+	tasks := make([]*models.Task, 0)
+
+	f := NewTaskFilter()
+	f.WithTaskRefs(taskRefs)
+	f.WithProjectID(projectID)
+
+	cursor, err := m.collection.Find(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	return tasks, nil
+}
+
 func (m *mongoTaskRepo) FindByProjectID(ctx context.Context, projectID bson.ObjectID) ([]*models.Task, error) {
 	tasks := make([]*models.Task, 0)
 
@@ -524,4 +544,23 @@ func (m *mongoTaskRepo) BulkUpdateCurrentSprintID(ctx context.Context, in *repos
 	}
 
 	return nil
+}
+
+func (m *mongoTaskRepo) FindByCurrentSprintIDs(ctx context.Context, sprintIDs []bson.ObjectID) ([]*models.Task, error) {
+	tasks := make([]*models.Task, 0)
+
+	f := NewTaskFilter()
+	f.WithCurrentSprintIDs(sprintIDs)
+
+	cursor, err := m.collection.Find(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	return tasks, nil
 }

--- a/internal/adapters/rest/report_handler.go
+++ b/internal/adapters/rest/report_handler.go
@@ -15,8 +15,8 @@ type ReportHandler interface {
 	GetStatusOverview(c echo.Context) error
 	GetPriorityOverview(c echo.Context) error
 	GetTypeOverview(c echo.Context) error
-	GetAssigneeOverview(c echo.Context) error
 	GetEpicTaskOverview(c echo.Context) error
+	GetAssigneeOverviewBySprint(c echo.Context) error
 }
 
 type reportHandlerImpl struct {
@@ -86,25 +86,6 @@ func (h *reportHandlerImpl) GetTypeOverview(c echo.Context) error {
 	return c.JSON(http.StatusOK, typeOverview)
 }
 
-func (h *reportHandlerImpl) GetAssigneeOverview(c echo.Context) error {
-	req := new(requests.GetTaskAssigneeOverviewRequest)
-	if err := c.Bind(req); err != nil {
-		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
-	}
-
-	if err := c.Validate(req); err != nil {
-		return err
-	}
-
-	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
-	assigneeOverview, err := h.reportService.GetAssigneeOverview(c.Request().Context(), req, userClaims.ID)
-	if err != nil {
-		return err.ToEchoError()
-	}
-
-	return c.JSON(http.StatusOK, assigneeOverview)
-}
-
 func (h *reportHandlerImpl) GetEpicTaskOverview(c echo.Context) error {
 	req := new(requests.GetEpicTaskOverviewRequest)
 	if err := c.Bind(req); err != nil {
@@ -122,4 +103,23 @@ func (h *reportHandlerImpl) GetEpicTaskOverview(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, epicTaskOverview)
+}
+
+func (h *reportHandlerImpl) GetAssigneeOverviewBySprint(c echo.Context) error {
+	req := new(requests.GetTaskAssigneeOverviewBySprintRequest)
+	if err := c.Bind(req); err != nil {
+		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+	assigneeOverview, err := h.reportService.GetAssigneeOverviewBySprint(c.Request().Context(), req, userClaims.ID)
+	if err != nil {
+		return err.ToEchoError()
+	}
+
+	return c.JSON(http.StatusOK, assigneeOverview)
 }

--- a/internal/adapters/rest/task_handler.go
+++ b/internal/adapters/rest/task_handler.go
@@ -14,6 +14,7 @@ import (
 type TaskHandler interface {
 	Create(c echo.Context) error
 	GetTaskDetail(c echo.Context) error
+	GetManyTaskDetail(c echo.Context) error
 	ListEpicTasks(c echo.Context) error
 	SearchTask(c echo.Context) error
 	UpdateDetail(c echo.Context) error
@@ -70,6 +71,25 @@ func (h *taskHandlerImpl) GetTaskDetail(c echo.Context) error {
 
 	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
 	resp, err := h.taskService.GetTaskDetail(c.Request().Context(), req, userClaims.ID)
+	if err != nil {
+		return err.ToEchoError()
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *taskHandlerImpl) GetManyTaskDetail(c echo.Context) error {
+	req := new(requests.GetManyTaskDetailPathParam)
+	if err := c.Bind(req); err != nil {
+		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+	resp, err := h.taskService.GetManyTaskDetail(c.Request().Context(), req, userClaims.ID)
 	if err != nil {
 		return err.ToEchoError()
 	}

--- a/internal/infrastructure/router/api_router.go
+++ b/internal/infrastructure/router/api_router.go
@@ -85,6 +85,7 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 	{
 		tasks.POST("", r.task.Create, r.authMiddleware.Middleware)
 		tasks.GET("/:taskRef", r.task.GetTaskDetail, r.authMiddleware.Middleware)
+		tasks.GET("/detail", r.task.GetManyTaskDetail, r.authMiddleware.Middleware)
 
 		tasks.GET("/epic", r.task.ListEpicTasks, r.authMiddleware.Middleware)
 		tasks.GET("", r.task.SearchTask, r.authMiddleware.Middleware)
@@ -112,8 +113,8 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 		reports.GET("/status-overview", r.report.GetStatusOverview, r.authMiddleware.Middleware)
 		reports.GET("/priority-overview", r.report.GetPriorityOverview, r.authMiddleware.Middleware)
 		reports.GET("/type-overview", r.report.GetTypeOverview, r.authMiddleware.Middleware)
-		reports.GET("/assignee-overview", r.report.GetAssigneeOverview, r.authMiddleware.Middleware)
 		reports.GET("/epic-task-overview", r.report.GetEpicTaskOverview, r.authMiddleware.Middleware)
+		reports.GET("/assignee-overview-by-sprint", r.report.GetAssigneeOverviewBySprint, r.authMiddleware.Middleware)
 	}
 
 	setup := api.Group("/setup/v1")

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -66,7 +66,7 @@ func InitializeApp() *api.EchoAPI {
 	taskHandler := rest.NewTaskHandler(taskService)
 	taskCommentService := services.NewTaskCommentService(userRepository, taskCommentRepository, taskRepository, projectRepository, projectMemberRepository)
 	taskCommentHandler := rest.NewTaskCommentHandler(taskCommentService)
-	reportService := services.NewReportService(userRepository, projectRepository, projectMemberRepository, taskRepository)
+	reportService := services.NewReportService(userRepository, projectRepository, projectMemberRepository, sprintRepository, taskRepository)
 	reportHandler := rest.NewReportHandler(reportService)
 	routerRouter := router.NewRouter(authMiddleware, healthCheckHandler, commonHandler, userHandler, projectHandler, projectMemberHandler, invitationHandler, workspaceHandler, sprintHandler, taskHandler, taskCommentHandler, reportHandler)
 	echoAPI := api.NewEchoAPI(context, configConfig, client, routerRouter)


### PR DESCRIPTION
This pull request includes several changes to the Sprint and Task repositories, as well as updates to various request and response structures to support new functionalities. The most important changes include adding new methods to the Sprint and Task repositories, updating request structures to handle multiple statuses, and modifying response structures to include new data fields.

### Repository Updates:

* [`domain/repositories/sprint_repo.go`](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1R19): Added `FindByProjectIDAndStatus` method to `SprintRepository` interface.
* [`domain/repositories/task_repo.go`](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR17): Added `FindByTaskRefsAndProjectID` and `FindByCurrentSprintIDs` methods to `TaskRepository` interface. [[1]](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR17) [[2]](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR40)

### Request Structure Updates:

* [`domain/repositories/sprint_repo.go`](diffhunk://#diff-7bb569570e02e98313a7e0b803007a0595297a3d13d10b8ef122e3531a9debe1L40-R41): Updated `ListSprintFilter` to use `Statuses` instead of `Status`.
* [`domain/requests/sprint_request.go`](diffhunk://#diff-bf78e9bc23448f261ec92ec17fd8c9c09187bda6327777806e0de2732728ef9bL27-R27): Updated `ListSprintPathParam` to use `Statuses` instead of `Status`.
* [`domain/requests/report_request.go`](diffhunk://#diff-bbc228a6f892bb052470b4ded5630a6a1b1dd27c1f070e9b91d7a952de29e0a0L15-R21): Renamed `GetTaskAssigneeOverviewRequest` to `GetEpicTaskOverviewRequest` and added `GetTaskAssigneeOverviewBySprintRequest` with `GetAllSprint` field.

### Response Structure Updates:

* [`domain/responses/report_response.go`](diffhunk://#diff-df6cc7e5c22e1cd615c46d9d0db32961a47099e14092c609735c4628abffb47dR54-R77): Added `GetAssigneeOverviewBySprintResponse` and related structures for detailed assignee overview by sprint.

### Service Updates:

* [`domain/services/report_service.go`](diffhunk://#diff-b72dfe3723362ee0d3b7869822d18df8f817a9f599aa26f5822f91caabc4d3f6L19-R42): Replaced `GetAssigneeOverview` with `GetAssigneeOverviewBySprint` in `ReportService` interface and implemented the new method. [[1]](diffhunk://#diff-b72dfe3723362ee0d3b7869822d18df8f817a9f599aa26f5822f91caabc4d3f6L19-R42) [[2]](diffhunk://#diff-b72dfe3723362ee0d3b7869822d18df8f817a9f599aa26f5822f91caabc4d3f6L207-R210)
* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fL22-R22): Updated `CompleteSprint` method in `SprintService` interface to return `*models.Sprint` instead of `*responses.CompleteSprintResponse`.