### PR TITLE
feat: implement service for getting children task by parent task reference.

### DIFF
--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -30,7 +30,7 @@ type GetTaskDetailPathParam struct {
 	TaskRef   string `param:"taskRef" validate:"required"`
 }
 
-type GetManyTaskDetailPathParam struct {
+type GetManyTaskDetailParams struct {
 	ProjectID string   `param:"projectId" validate:"required"`
 	TaskRefs  []string `query:"taskRefs" validate:"required"`
 }
@@ -48,6 +48,11 @@ type SearchTaskParams struct {
 	Positions       []string `query:"positions"`
 	Statuses        []string `query:"statuses"`
 	SearchKeyword   *string  `query:"searchKeyword"`
+}
+
+type GetChildrenTasksParams struct {
+	ProjectID     string `param:"projectId" validate:"required"`
+	ParentTaskRef string `query:"parentTaskRef" validate:"required"`
 }
 
 type UpdateTaskDetailRequest struct {

--- a/domain/responses/task_response.go
+++ b/domain/responses/task_response.go
@@ -78,6 +78,18 @@ type SearchTaskResponseAssignee struct {
 	Point       *int    `json:"point"`
 }
 
+type GetChildrenTasksResponse struct {
+	ID        string                           `json:"id"`
+	TaskRef   string                           `json:"taskRef"`
+	ProjectID string                           `json:"projectId"`
+	Title     string                           `json:"title"`
+	Type      string                           `json:"type"`
+	Status    string                           `json:"status"`
+	Priority  string                           `json:"priority"`
+	Approvals []GetTaskDetailResponseApprovals `json:"approvals"`
+	Assignees []GetTaskDetailResponseAssignee  `json:"assignees"`
+}
+
 type GenerateDescriptionResponse struct {
 	Description []genai.Part `json:"description"`
 }

--- a/domain/services/report_service.go
+++ b/domain/services/report_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cnc-csku/task-nexus-go-lib/utils/errutils"
 	"github.com/cnc-csku/task-nexus/task-management/domain/exceptions"
@@ -352,6 +353,10 @@ func (s *reportServiceImpl) GetAssigneeOverviewBySprint(ctx context.Context, req
 		}
 	} else {
 		activeSprints, err := s.sprintRepo.FindByProjectIDAndStatus(ctx, bsonProjectID, models.SprintStatusInProgress)
+		fmt.Println("len(activeSprints)", len(activeSprints))
+		for _, sprint := range activeSprints {
+			fmt.Println("sprint", sprint)
+		}
 		if err != nil {
 			return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 		} else if len(activeSprints) == 0 {

--- a/domain/services/report_service.go
+++ b/domain/services/report_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cnc-csku/task-nexus-go-lib/utils/errutils"
 	"github.com/cnc-csku/task-nexus/task-management/domain/exceptions"
@@ -353,10 +352,6 @@ func (s *reportServiceImpl) GetAssigneeOverviewBySprint(ctx context.Context, req
 		}
 	} else {
 		activeSprints, err := s.sprintRepo.FindByProjectIDAndStatus(ctx, bsonProjectID, models.SprintStatusInProgress)
-		fmt.Println("len(activeSprints)", len(activeSprints))
-		for _, sprint := range activeSprints {
-			fmt.Println("sprint", sprint)
-		}
 		if err != nil {
 			return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 		} else if len(activeSprints) == 0 {

--- a/domain/services/sprint_service.go
+++ b/domain/services/sprint_service.go
@@ -331,8 +331,9 @@ func (s *sprintServiceImpl) UpdateStatus(ctx context.Context, req *requests.Upda
 	}
 
 	sprint, err = s.sprintRepo.UpdateStatus(ctx, &repositories.UpdateSprintStatusRequest{
-		ID:     bsonSprintID,
-		Status: models.SprintStatus(req.Status),
+		ID:        bsonSprintID,
+		Status:    models.SprintStatus(req.Status),
+		UpdatedBy: bsonUserID,
 	})
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())

--- a/internal/adapters/rest/task_handler.go
+++ b/internal/adapters/rest/task_handler.go
@@ -17,6 +17,7 @@ type TaskHandler interface {
 	GetManyTaskDetail(c echo.Context) error
 	ListEpicTasks(c echo.Context) error
 	SearchTask(c echo.Context) error
+	GetChildrenTasks(c echo.Context) error
 	UpdateDetail(c echo.Context) error
 	UpdateTitle(c echo.Context) error
 	UpdateParentID(c echo.Context) error
@@ -79,7 +80,7 @@ func (h *taskHandlerImpl) GetTaskDetail(c echo.Context) error {
 }
 
 func (h *taskHandlerImpl) GetManyTaskDetail(c echo.Context) error {
-	req := new(requests.GetManyTaskDetailPathParam)
+	req := new(requests.GetManyTaskDetailParams)
 	if err := c.Bind(req); err != nil {
 		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
 	}
@@ -128,6 +129,25 @@ func (h *taskHandlerImpl) SearchTask(c echo.Context) error {
 
 	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
 	resp, err := h.taskService.SearchTask(c.Request().Context(), req, userClaims.ID)
+	if err != nil {
+		return err.ToEchoError()
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *taskHandlerImpl) GetChildrenTasks(c echo.Context) error {
+	req := new(requests.GetChildrenTasksParams)
+	if err := c.Bind(req); err != nil {
+		return errutils.NewError(err, errutils.BadRequest).ToEchoError()
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	userClaims := tokenutils.GetProfileOnEchoContext(c).(*models.UserCustomClaims)
+	resp, err := h.taskService.GetChildrenTasks(c.Request().Context(), req, userClaims.ID)
 	if err != nil {
 		return err.ToEchoError()
 	}

--- a/internal/infrastructure/router/api_router.go
+++ b/internal/infrastructure/router/api_router.go
@@ -89,6 +89,7 @@ func (r *Router) RegisterAPIRouter(e *echo.Echo) {
 
 		tasks.GET("/epic", r.task.ListEpicTasks, r.authMiddleware.Middleware)
 		tasks.GET("", r.task.SearchTask, r.authMiddleware.Middleware)
+		tasks.GET("/children", r.task.GetChildrenTasks, r.authMiddleware.Middleware)
 
 		tasks.PUT("/:taskRef/detail", r.task.UpdateDetail, r.authMiddleware.Middleware)
 		tasks.PUT("/:taskRef/title", r.task.UpdateTitle, r.authMiddleware.Middleware)


### PR DESCRIPTION
This pull request includes several changes to the task management system, focusing on adding functionality to retrieve child tasks, updating task details, and improving logging for debugging. The most important changes include the addition of new request and response types for handling child tasks, method updates to support these new types, and enhanced logging in the report service.

### New functionality for retrieving child tasks:

* [`domain/requests/task_request.go`](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfR53-R57): Added `GetChildrenTasksParams` struct for handling parameters related to retrieving child tasks.
* [`domain/responses/task_response.go`](diffhunk://#diff-192689da52d050ec14d0f619030dea33f921208c848e1d21657b2a26a4b09e07R81-R92): Added `GetChildrenTasksResponse` struct for handling responses related to child tasks.
* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR947-R1087): Implemented `GetChildrenTasks` method in `taskServiceImpl` to retrieve child tasks based on the parent task reference.
* [`internal/adapters/rest/task_handler.go`](diffhunk://#diff-a3844031fe3a115ecca51c20d7bf2965419c3b3c8e430e537d0f5c74cb47317fR139-R157): Added `GetChildrenTasks` method in `taskHandlerImpl` to handle HTTP requests for retrieving child tasks.
* [`internal/infrastructure/router/api_router.go`](diffhunk://#diff-8ca79d75f53a2d8a64a4d1eff6e541adbb66b2047edff5c4f7ed23a006a7dcb9R92): Registered the new endpoint `/tasks/children` for retrieving child tasks.

### Updates to existing methods and types:

* [`domain/requests/task_request.go`](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfL33-R33): Renamed `GetManyTaskDetailPathParam` to `GetManyTaskDetailParams` for consistency.
* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL534-R535): Updated method signatures to use the new `GetManyTaskDetailParams` type.
* [`internal/adapters/rest/task_handler.go`](diffhunk://#diff-a3844031fe3a115ecca51c20d7bf2965419c3b3c8e430e537d0f5c74cb47317fL82-R83): Updated `GetManyTaskDetail` method to use the new `GetManyTaskDetailParams` type.

### Enhanced logging for debugging:

* [`domain/services/report_service.go`](diffhunk://#diff-b72dfe3723362ee0d3b7869822d18df8f817a9f599aa26f5822f91caabc4d3f6R356-R359): Added logging to print the length and details of active sprints in the `GetAssigneeOverviewBySprint` method.

### Minor changes:

* [`domain/services/sprint_service.go`](diffhunk://#diff-cffaf14dd5a49efb6b0b2b403ea289e0db13c10bf3e80c74a16b6d6420e9b60fR336): Added `UpdatedBy` field to the `UpdateStatus` method to track the user making the update.
* [`domain/services/report_service.go`](diffhunk://#diff-b72dfe3723362ee0d3b7869822d18df8f817a9f599aa26f5822f91caabc4d3f6R5): Imported `fmt` package for logging purposes.