### PR TITLE
feat: add priority to the response of task searching api.

### DIFF
--- a/domain/models/project.go
+++ b/domain/models/project.go
@@ -18,7 +18,7 @@ type Project struct {
 	Workflows           []ProjectWorkflow          `bson:"workflows" json:"workflows"`
 	AttributeTemplates  []ProjectAttributeTemplate `bson:"attributes_templates" json:"attributesTemplates"`
 	Positions           []string                   `bson:"positions" json:"positions"`
-	SetupStatus         ProjectStatus              `bson:"setup_status" json:"setupStatus"`
+	SetupStatus         ProjectSetupStatus         `bson:"setup_status" json:"setupStatus"`
 	CreatedAt           time.Time                  `bson:"created_at" json:"createdAt"`
 	CreatedBy           bson.ObjectID              `bson:"created_by" json:"createdBy"`
 	UpdatedAt           time.Time                  `bson:"updated_at" json:"updatedAt"`

--- a/domain/responses/task_response.go
+++ b/domain/responses/task_response.go
@@ -62,6 +62,7 @@ type SearchTaskResponse struct {
 	ParentTitle   *string                      `json:"parentTitle"`
 	Type          string                       `json:"type"`
 	Status        string                       `json:"status"`
+	Priority      string                       `json:"priority"`
 	Assignees     []SearchTaskResponseAssignee `json:"assignees"`
 	Approvals     []models.TaskApproval        `json:"approvals"`
 	ChildrenPoint int                          `json:"childrenPoint"`

--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -902,6 +902,7 @@ func (s *taskServiceImpl) SearchTask(ctx context.Context, req *requests.SearchTa
 			ParentTitle:   parentTitleResp,
 			Type:          task.Type.String(),
 			Status:        task.Status,
+			Priority:      task.Priority.String(),
 			Assignees:     assigneeResponses,
 			Approvals:     task.Approvals,
 			ChildrenPoint: task.ChildrenPoint,


### PR DESCRIPTION
This pull request includes changes to the `domain/models`, `domain/responses`, and `domain/services` packages to update types and add new fields. The most important changes include updating the `Project` struct to use a different status type, adding a priority field to the `SearchTaskResponse` struct, and ensuring the `SearchTask` function populates the new priority field.

Updates to types:

* [`domain/models/project.go`](diffhunk://#diff-9ea8121e70b0308c599301e8f99c2a4f98f8e6834b72c705c86758ef1dbaa83eL21-R21): Changed the `SetupStatus` field in the `Project` struct from `ProjectStatus` to `ProjectSetupStatus`.

Enhancements to task responses:

* [`domain/responses/task_response.go`](diffhunk://#diff-192689da52d050ec14d0f619030dea33f921208c848e1d21657b2a26a4b09e07R65): Added a `Priority` field to the `SearchTaskResponse` struct.
* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR905): Updated the `SearchTask` function to populate the `Priority` field in the `SearchTaskResponse`.