### PR TITLE
feat: add task type to search task service's filter selection.

### DIFF
--- a/domain/requests/task_request.go
+++ b/domain/requests/task_request.go
@@ -48,6 +48,7 @@ type SearchTaskParams struct {
 	Positions       []string `query:"positions"`
 	Statuses        []string `query:"statuses"`
 	SearchKeyword   *string  `query:"searchKeyword"`
+	Types           []string `query:"types"`
 }
 
 type GetChildrenTasksParams struct {

--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -745,6 +745,14 @@ func (s *taskServiceImpl) SearchTask(ctx context.Context, req *requests.SearchTa
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
+	var taskTypes []models.TaskType
+	for _, taskType := range req.Types {
+		if !models.TaskType(taskType).IsValid() {
+			return nil, errutils.NewError(exceptions.ErrInvalidTaskType, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Invalid task type: %s", taskType))
+		}
+		taskTypes = append(taskTypes, models.TaskType(taskType))
+	}
+
 	var (
 		isTaskWithNoSprint bool
 		bsonSprintIDs      []bson.ObjectID
@@ -811,7 +819,7 @@ func (s *taskServiceImpl) SearchTask(ctx context.Context, req *requests.SearchTa
 
 	tasks, err := s.taskRepo.Search(ctx, &repositories.SearchTaskRequest{
 		ProjectID:          bsonProjectID,
-		TaskTypes:          []models.TaskType{models.TaskTypeStory, models.TaskTypeTask, models.TaskTypeBug},
+		TaskTypes:          taskTypes,
 		SprintIDs:          bsonSprintIDs,
 		IsTaskWithNoSprint: isTaskWithNoSprint,
 		EpicTaskID:         bsonParentID,


### PR DESCRIPTION
This pull request introduces changes to support filtering tasks by their types in the task search functionality. The main updates include adding a new field to the search parameters, validating task types, and passing the validated types to the repository search method.

### Enhancements to Task Search Functionality:

* [`domain/requests/task_request.go`](diffhunk://#diff-9bc80084c1b14d40f1b6c1908219f7ef3009d00c5a0baee369ec7062c3ffd4cfR51): Added a new `Types` field to the `SearchTaskParams` struct to allow filtering by task types.

* `domain/services/task_service.go`: 
  * Added validation for task types in the `SearchTask` method to ensure only valid task types are processed. Invalid task types will now return an error.
  * Modified the `SearchTask` method to use the validated task types when calling the repository search method, replacing the hardcoded task types.