### PR TITLE
feat: improve task's status updating service logic to automatically update the status parent or child task in certain conditions.

### DIFF
--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -38,6 +38,7 @@ type TaskRepository interface {
 	FindByCurrentSprintIDAndPreviousSprintIDs(ctx context.Context, sprintID bson.ObjectID) ([]*models.Task, error)
 	BulkUpdateCurrentSprintID(ctx context.Context, in *BulkUpdateCurrentSprintIDRequest) error
 	FindByCurrentSprintIDs(ctx context.Context, sprintIDs []bson.ObjectID) ([]*models.Task, error)
+	UpdateManyTasksStatus(ctx context.Context, in *UpdateManyTasksStatusRequest) error
 }
 
 type CreateTaskRequest struct {
@@ -166,4 +167,10 @@ type BulkUpdateCurrentSprintIDRequest struct {
 	TaskIDs         []bson.ObjectID
 	CurrentSprintID *bson.ObjectID
 	UpdatedBy       bson.ObjectID
+}
+
+type UpdateManyTasksStatusRequest struct {
+	TaskIDs   []bson.ObjectID
+	Status    string
+	UpdatedBy bson.ObjectID
 }

--- a/domain/services/task_service.go
+++ b/domain/services/task_service.go
@@ -1479,6 +1479,20 @@ func (s *taskServiceImpl) UpdateStatus(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.BadRequest).WithDebugMessage(err.Error())
 	}
 
+	project, err := s.projectRepo.FindByProjectID(ctx, bsonProjectID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if project == nil {
+		return nil, errutils.NewError(exceptions.ErrProjectNotFound, errutils.BadRequest)
+	}
+
+	member, err := s.projectMemberRepo.FindByProjectIDAndUserID(ctx, bsonProjectID, bsonUserID)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if member == nil {
+		return nil, errutils.NewError(exceptions.ErrPermissionDenied, errutils.BadRequest).WithDebugMessage("User is not a member of the project")
+	}
+
 	task, err := s.taskRepo.FindByTaskRefAndProjectID(ctx, req.TaskID, bsonProjectID)
 	if err != nil {
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
@@ -1486,26 +1500,12 @@ func (s *taskServiceImpl) UpdateStatus(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrTaskNotFound, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Task not found: %s", req.TaskID))
 	}
 
-	member, err := s.projectMemberRepo.FindByProjectIDAndUserID(ctx, task.ProjectID, bsonUserID)
-	if err != nil {
-		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
-	} else if member == nil {
-		return nil, errutils.NewError(exceptions.ErrPermissionDenied, errutils.BadRequest).WithDebugMessage("User is not a member of the project")
-	}
-
-	project, err := s.projectRepo.FindByProjectID(ctx, task.ProjectID)
-	if err != nil {
-		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
-	} else if project == nil {
-		return nil, errutils.NewError(exceptions.ErrProjectNotFound, errutils.BadRequest)
-	}
-
-	statuses := make([]string, 0, len(project.Workflows))
+	validStatuses := make([]string, 0, len(project.Workflows))
 	for _, workflow := range project.Workflows {
-		statuses = append(statuses, workflow.Status)
+		validStatuses = append(validStatuses, workflow.Status)
 	}
 
-	if !array.ContainAny(statuses, []string{req.Status}) {
+	if !array.ContainAny(validStatuses, []string{req.Status}) {
 		return nil, errutils.NewError(exceptions.ErrInvalidTaskStatus, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Invalid task status: %s", req.Status))
 	}
 
@@ -1518,7 +1518,133 @@ func (s *taskServiceImpl) UpdateStatus(ctx context.Context, req *requests.Update
 		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
 	}
 
+	// If the updated task is the level 1 task (Task, Story, Bug)
+	// Update all children tasks' status to the updated parent task's status
+	if array.ContainAny(
+		[]string{task.Type.String()},
+		[]string{models.TaskTypeStory.String(), models.TaskTypeTask.String(), models.TaskTypeBug.String()},
+	) {
+		childrenTasks, err := s.taskRepo.FindByParentID(ctx, task.ID)
+		if err != nil {
+			return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		} else if len(childrenTasks) != 0 {
+			childrenTaskBsonIDs := make([]bson.ObjectID, 0, len(childrenTasks))
+			for _, childrenTask := range childrenTasks {
+				childrenTaskBsonIDs = append(childrenTaskBsonIDs, childrenTask.ID)
+			}
+
+			err = s.taskRepo.UpdateManyTasksStatus(ctx, &repositories.UpdateManyTasksStatusRequest{
+				TaskIDs:   childrenTaskBsonIDs,
+				Status:    req.Status,
+				UpdatedBy: bsonUserID,
+			})
+			if err != nil {
+				return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+		}
+
+	} else if updatedTask.Type == models.TaskTypeSubTask {
+		// If the updated task is a SubTask
+		// Update the parent task's status to the lowest status of all children tasks
+		if updatedTask.ParentID != nil {
+			parentTask, err := s.taskRepo.FindByID(ctx, *updatedTask.ParentID)
+			if err != nil {
+				return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			} else if parentTask == nil {
+				return nil, errutils.NewError(exceptions.ErrParentTaskNotFound, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task not found: %s", *updatedTask.ParentID))
+			}
+
+			childrenTasks, err := s.taskRepo.FindByParentID(ctx, parentTask.ID)
+			if err != nil {
+				return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+
+			// Step 1: Sort workflows
+			sortedWorkflows := sortWorkflows(project.Workflows)
+
+			// Step 2: Find the lowest workflow status in children tasks
+			statusIndexMap := make(map[string]int)
+			for i, workflow := range sortedWorkflows {
+				statusIndexMap[workflow.Status] = i
+			}
+
+			minIndex := len(sortedWorkflows) // Set to max initially
+			for _, child := range childrenTasks {
+				if idx, exists := statusIndexMap[child.Status]; exists && idx < minIndex {
+					minIndex = idx
+				}
+			}
+
+			// Step 3: Update the parent task to the lowest status found
+			if minIndex < len(sortedWorkflows) {
+				newParentStatus := sortedWorkflows[minIndex].Status
+				if parentTask.Status != newParentStatus { // Only update if different
+					_, err = s.taskRepo.UpdateStatus(ctx, &repositories.UpdateTaskStatusRequest{
+						ID:        parentTask.ID,
+						Status:    newParentStatus,
+						UpdatedBy: bsonUserID,
+					})
+					if err != nil {
+						return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+					}
+				}
+			}
+		}
+	}
+
 	return updatedTask, nil
+}
+
+func sortWorkflows(workflows []models.ProjectWorkflow) []models.ProjectWorkflow {
+	// Step 1: Build graph adjacency list and in-degree map
+	graph := make(map[string][]string)
+	inDegree := make(map[string]int)
+	statusMap := make(map[string]models.ProjectWorkflow)
+
+	// Initialize graph nodes
+	for _, workflow := range workflows {
+		statusMap[workflow.Status] = workflow
+		if _, exists := inDegree[workflow.Status]; !exists {
+			inDegree[workflow.Status] = 0
+		}
+	}
+
+	// Populate the adjacency list and compute in-degree
+	for _, workflow := range workflows {
+		for _, prevStatus := range workflow.PreviousStatuses {
+			graph[prevStatus] = append(graph[prevStatus], workflow.Status)
+			inDegree[workflow.Status]++ // Increase in-degree for the dependent status
+		}
+	}
+
+	// Step 2: Find all statuses with in-degree 0 (starting points)
+	var queue []string
+	for status, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, status)
+		}
+	}
+
+	// Step 3: Perform Topological Sort
+	var sortedWorkflows []models.ProjectWorkflow
+	for len(queue) > 0 {
+		// Dequeue a status
+		current := queue[0]
+		queue = queue[1:]
+
+		// Append to the sorted order
+		sortedWorkflows = append(sortedWorkflows, statusMap[current])
+
+		// Reduce in-degree for its children and enqueue if they become 0
+		for _, nextStatus := range graph[current] {
+			inDegree[nextStatus]--
+			if inDegree[nextStatus] == 0 {
+				queue = append(queue, nextStatus)
+			}
+		}
+	}
+
+	return sortedWorkflows
 }
 
 func (s *taskServiceImpl) UpdateApprovals(ctx context.Context, req *requests.UpdateTaskApprovalsRequest, userID string) (*models.Task, *errutils.Error) {

--- a/internal/adapters/repositories/mongo/mongo_task_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_task_bson.go
@@ -164,11 +164,11 @@ func (u taskUpdate) UpdateType(in *repositories.UpdateTaskTypeRequest) {
 	}
 }
 
-func (u taskUpdate) UpdateStatus(in *repositories.UpdateTaskStatusRequest) {
+func (u taskUpdate) UpdateStatus(status string, updatedBy bson.ObjectID) {
 	u["$set"] = bson.M{
-		"status":     in.Status,
+		"status":     status,
 		"updated_at": time.Now(),
-		"updated_by": in.UpdatedBy,
+		"updated_by": updatedBy,
 	}
 }
 

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -232,7 +232,7 @@ func (m *mongoTaskRepo) UpdateStatus(ctx context.Context, in *repositories.Updat
 	f.WithID(in.ID)
 
 	u := NewTaskUpdate()
-	u.UpdateStatus(in)
+	u.UpdateStatus(in.Status, in.UpdatedBy)
 
 	err := m.collection.FindOneAndUpdate(ctx, f, u).Err()
 	if err != nil {
@@ -563,4 +563,19 @@ func (m *mongoTaskRepo) FindByCurrentSprintIDs(ctx context.Context, sprintIDs []
 	}
 
 	return tasks, nil
+}
+
+func (m *mongoTaskRepo) UpdateManyTasksStatus(ctx context.Context, in *repositories.UpdateManyTasksStatusRequest) error {
+	f := NewTaskFilter()
+	f.WithIDs(in.TaskIDs)
+
+	u := NewTaskUpdate()
+	u.UpdateStatus(in.Status, in.UpdatedBy)
+
+	_, err := m.collection.UpdateMany(ctx, f, u)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This pull request introduces several changes to the task management system, primarily focusing on updating task statuses and ensuring consistency between parent and child tasks. The changes include adding new methods to handle bulk status updates and modifying existing methods to accommodate these updates.

### Task Status Updates and Consistency:

* [`domain/repositories/task_repo.go`](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR41): Added a new method `UpdateManyTasksStatus` to the `TaskRepository` interface and defined the `UpdateManyTasksStatusRequest` struct. [[1]](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR41) [[2]](diffhunk://#diff-4f83860f9a83ab1bfdf90cb202bcb4b5f3a00a79d9eb169b5d1fc7cbb8a02fceR171-R176)

* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1482-R1508): Modified the `UpdateStatus` method to update the status of child tasks when a parent task's status is updated and to update the parent task's status based on the statuses of its child tasks. Introduced a helper function `sortWorkflows` to sort project workflows for status consistency checks. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1482-R1508) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR1521-R1649)

### Repository Methods Updates:

* [`internal/adapters/repositories/mongo/mongo_task_bson.go`](diffhunk://#diff-a11be1fb39f9e88ef778200b38f91c510127825f79edfa1a37ec039bdcd9d255L167-R171): Updated the `UpdateStatus` method to accept status and updatedBy parameters directly instead of an `UpdateTaskStatusRequest` struct.

* [`internal/adapters/repositories/mongo/mongo_task_repo.go`](diffhunk://#diff-52271912ff49328dc08bd27d0d6209b669b3e89d928ad4ead0b44900da5718c3L235-R235): Modified the `UpdateStatus` method to match the new signature and added a new method `UpdateManyTasksStatus` to handle bulk status updates. [[1]](diffhunk://#diff-52271912ff49328dc08bd27d0d6209b669b3e89d928ad4ead0b44900da5718c3L235-R235) [[2]](diffhunk://#diff-52271912ff49328dc08bd27d0d6209b669b3e89d928ad4ead0b44900da5718c3R567-R581)