### PR TITLE
feat: refactor task status update logic and extract helper functions for better maintainability

### DIFF
--- a/domain/services/task_service_helper.go
+++ b/domain/services/task_service_helper.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+
+	"github.com/cnc-csku/task-nexus-go-lib/utils/errutils"
+	"github.com/cnc-csku/task-nexus/task-management/domain/exceptions"
+	"github.com/cnc-csku/task-nexus/task-management/domain/models"
+	"github.com/cnc-csku/task-nexus/task-management/domain/repositories"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func sortWorkflows(workflows []models.ProjectWorkflow) []models.ProjectWorkflow {
+	// Step 1: Build graph adjacency list and in-degree map
+	graph := make(map[string][]string)
+	inDegree := make(map[string]int)
+	statusMap := make(map[string]models.ProjectWorkflow)
+
+	// Initialize graph nodes
+	for _, workflow := range workflows {
+		statusMap[workflow.Status] = workflow
+		if _, exists := inDegree[workflow.Status]; !exists {
+			inDegree[workflow.Status] = 0
+		}
+	}
+
+	// Populate the adjacency list and compute in-degree
+	for _, workflow := range workflows {
+		for _, prevStatus := range workflow.PreviousStatuses {
+			graph[prevStatus] = append(graph[prevStatus], workflow.Status)
+			inDegree[workflow.Status]++ // Increase in-degree for the dependent status
+		}
+	}
+
+	// Step 2: Find all statuses with in-degree 0 (starting points)
+	var queue []string
+	for status, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, status)
+		}
+	}
+
+	// Step 3: Perform Topological Sort
+	var sortedWorkflows []models.ProjectWorkflow
+	for len(queue) > 0 {
+		// Dequeue a status
+		current := queue[0]
+		queue = queue[1:]
+
+		// Append to the sorted order
+		sortedWorkflows = append(sortedWorkflows, statusMap[current])
+
+		// Reduce in-degree for its children and enqueue if they become 0
+		for _, nextStatus := range graph[current] {
+			inDegree[nextStatus]--
+			if inDegree[nextStatus] == 0 {
+				queue = append(queue, nextStatus)
+			}
+		}
+	}
+
+	return sortedWorkflows
+}
+
+type UpdateParentTaskStatusToLowestWorkflowStatus struct {
+	taskRepo      repositories.TaskRepository
+	Workflows     []models.ProjectWorkflow
+	ChildrenTasks []*models.Task
+	ParentTask    *models.Task
+	UpdaterUserID bson.ObjectID
+}
+
+func updateParentTaskStatusToLowestWorkflowStatus(ctx context.Context, in *UpdateParentTaskStatusToLowestWorkflowStatus) *errutils.Error {
+	// Step 1: Sort workflows
+	sortedWorkflows := sortWorkflows(in.Workflows)
+
+	// Step 2: Find the lowest workflow status in children tasks
+	statusIndexMap := make(map[string]int)
+	for i, workflow := range sortedWorkflows {
+		statusIndexMap[workflow.Status] = i
+	}
+
+	minIndex := len(sortedWorkflows) // Set to max initially
+	for _, child := range in.ChildrenTasks {
+		if idx, exists := statusIndexMap[child.Status]; exists && idx < minIndex {
+			minIndex = idx
+		}
+	}
+
+	// Step 3: Update the parent task to the lowest status found
+	if minIndex < len(sortedWorkflows) {
+		newParentStatus := sortedWorkflows[minIndex].Status
+		if in.ParentTask.Status != newParentStatus { // Only update if different
+			_, err := in.taskRepo.UpdateStatus(ctx, &repositories.UpdateTaskStatusRequest{
+				ID:        in.ParentTask.ID,
+				Status:    newParentStatus,
+				UpdatedBy: in.UpdaterUserID,
+			})
+			if err != nil {
+				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request focuses on refactoring and improving the task status update logic in the `taskServiceImpl` service. The main changes involve moving the workflow sorting and parent task status update logic to a new helper function, thereby simplifying the main service functions.

Refactoring and code simplification:

* [`domain/services/task_service.go`](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR307-R322): Refactored the `Create` and `UpdateStatus` methods to use the new `updateParentTaskStatusToLowestWorkflowStatus` helper function, removing redundant workflow sorting and status update logic. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eR307-R322) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1562-L1649)

New helper function:

* [`domain/services/task_service_helper.go`](diffhunk://#diff-39fa7da9376f627cda48c3c49fe4ed955361e16568e759efd63246e23e2c264dR1-R106): Added a new file that includes the `sortWorkflows` function and the `updateParentTaskStatusToLowestWorkflowStatus` helper function to encapsulate the logic for sorting workflows and updating the parent task status.