### PR TITLE
feat: add the logic of level 1 task can have point initially but can't if it does have children.

### DIFF
--- a/domain/services/task_service_helper.go
+++ b/domain/services/task_service_helper.go
@@ -2,13 +2,165 @@ package services
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/cnc-csku/task-nexus-go-lib/utils/array"
 	"github.com/cnc-csku/task-nexus-go-lib/utils/errutils"
 	"github.com/cnc-csku/task-nexus/task-management/domain/exceptions"
 	"github.com/cnc-csku/task-nexus/task-management/domain/models"
 	"github.com/cnc-csku/task-nexus/task-management/domain/repositories"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
+
+func validateParentTaskType(childTaskType string, parentTaskType models.TaskType) *errutils.Error {
+	switch childTaskType {
+	case models.TaskTypeEpic.String():
+		return errutils.NewError(exceptions.ErrInvalidParentTaskType, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task type is not valid: %s", parentTaskType))
+	case models.TaskTypeStory.String(), models.TaskTypeTask.String(), models.TaskTypeBug.String():
+		if parentTaskType != models.TaskTypeEpic {
+			return errutils.NewError(exceptions.ErrInvalidParentTaskType, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task type is not valid: %s", parentTaskType))
+		}
+	case models.TaskTypeSubTask.String():
+		if !array.ContainAny(
+			[]string{parentTaskType.String()},
+			[]string{
+				models.TaskTypeStory.String(),
+				models.TaskTypeTask.String(),
+				models.TaskTypeBug.String(),
+			},
+		) {
+			return errutils.NewError(exceptions.ErrInvalidParentTaskType, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task type is not valid: %s", parentTaskType))
+		}
+	}
+	return nil
+}
+
+func getDoneStatuses(project *models.Project) []string {
+	isDoneStatuses := make([]string, 0)
+	for _, workflow := range project.Workflows {
+		if workflow.IsDone {
+			isDoneStatuses = append(isDoneStatuses, workflow.Status)
+		}
+	}
+	return isDoneStatuses
+}
+
+func getParentTasksMap(ctx context.Context, taskRepo repositories.TaskRepository, tasks []*models.Task) (map[string]*string, *errutils.Error) {
+	parentTaskIDs := make([]bson.ObjectID, 0, len(tasks))
+	for _, task := range tasks {
+		if task.ParentID != nil {
+			parentTaskIDs = append(parentTaskIDs, *task.ParentID)
+		}
+	}
+
+	parentTasks, err := taskRepo.FindByIDs(ctx, parentTaskIDs)
+	if err != nil {
+		return nil, errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	}
+
+	parentTasksMap := make(map[string]*string, len(parentTasks))
+	for _, parentTask := range parentTasks {
+		parentTasksMap[parentTask.ID.Hex()] = &parentTask.Title
+	}
+
+	return parentTasksMap, nil
+}
+
+func updatePreviousParentTask(
+	ctx context.Context,
+	taskRepo repositories.TaskRepository,
+	updatedTask *models.Task,
+) *errutils.Error {
+	if updatedTask.ParentID == nil {
+		return nil
+	}
+
+	previousParentTask, err := taskRepo.FindByID(ctx, *updatedTask.ParentID)
+	if err != nil {
+		return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if previousParentTask == nil {
+		return errutils.NewError(exceptions.ErrParentTaskNotFound, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task not found: %s", *updatedTask.ParentID))
+	}
+
+	childrenOfPreviousParentTasks, err := taskRepo.FindByParentID(ctx, previousParentTask.ID)
+	if err != nil {
+		return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	}
+
+	if len(childrenOfPreviousParentTasks) == 0 {
+		_, err := taskRepo.UpdateHasChildren(ctx, &repositories.UpdateTaskHasChildrenRequest{
+			ID:          previousParentTask.ID,
+			HasChildren: false,
+		})
+		if err != nil {
+			return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		}
+	}
+
+	serviceErr := updateChildrenPointOfPreviousParentTask(ctx, taskRepo, updatedTask, previousParentTask)
+	if serviceErr != nil {
+		return serviceErr
+	}
+
+	return nil
+}
+
+func updateChildrenPointOfPreviousParentTask(
+	ctx context.Context,
+	taskRepo repositories.TaskRepository,
+	updatedTask, previousParentTask *models.Task,
+) *errutils.Error {
+	if previousParentTask.Type == models.TaskTypeEpic {
+		_, err := taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+			ID:            previousParentTask.ID,
+			ChildrenPoint: previousParentTask.ChildrenPoint - updatedTask.ChildrenPoint,
+		})
+		if err != nil {
+			return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		}
+	} else if array.ContainAny(
+		[]string{previousParentTask.Type.String()},
+		[]string{
+			models.TaskTypeStory.String(),
+			models.TaskTypeTask.String(),
+			models.TaskTypeBug.String(),
+		},
+	) {
+		// Current previous parent task is a story, task, or bug
+		var totalPoint int
+		for _, assignee := range updatedTask.Assignees {
+			if assignee.Point != nil {
+				totalPoint += *assignee.Point
+			}
+		}
+
+		_, err := taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+			ID:            previousParentTask.ID,
+			ChildrenPoint: previousParentTask.ChildrenPoint - totalPoint,
+		})
+		if err != nil {
+			return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		}
+
+		// Update children point of the previous parent task's parent task (EPIC)
+		if previousParentTask.ParentID != nil {
+			epicParentTask, err := taskRepo.FindByID(ctx, *previousParentTask.ParentID)
+			if err != nil {
+				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+
+			_, err = taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+				ID:            *previousParentTask.ParentID,
+				ChildrenPoint: epicParentTask.ChildrenPoint - totalPoint,
+			})
+			if err != nil {
+				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+		}
+	}
+
+	return nil
+}
 
 func sortWorkflows(workflows []models.ProjectWorkflow) []models.ProjectWorkflow {
 	// Step 1: Build graph adjacency list and in-degree map
@@ -95,6 +247,85 @@ func updateParentTaskStatusToLowestWorkflowStatus(ctx context.Context, in *Updat
 				ID:        in.ParentTask.ID,
 				Status:    newParentStatus,
 				UpdatedBy: in.UpdaterUserID,
+			})
+			if err != nil {
+				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func assigneeesContainPoint(assignees []models.TaskAssignee) bool {
+	for _, assignee := range assignees {
+		if assignee.Point != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func updateParentTaskPoints(
+	ctx context.Context,
+	taskRepo repositories.TaskRepository,
+	task *models.Task,
+	assignees []repositories.UpdateTaskAssigneesRequestAssignee,
+	currentTotalPoint int,
+) *errutils.Error {
+	if task.ParentID == nil {
+		return nil
+	}
+
+	parentTask, err := taskRepo.FindByID(ctx, *task.ParentID)
+	if err != nil {
+		return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+	} else if parentTask == nil {
+		return errutils.NewError(exceptions.ErrParentTaskNotFound, errutils.BadRequest).WithDebugMessage(fmt.Sprintf("Parent task not found: %s", task.ParentID.Hex()))
+	}
+
+	var newTotalPoint int
+	for _, assignee := range assignees {
+		if assignee.Point != nil {
+			newTotalPoint += *assignee.Point
+		}
+	}
+
+	if parentTask.Type == models.TaskTypeEpic {
+		_, err := taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+			ID:            *task.ParentID,
+			ChildrenPoint: parentTask.ChildrenPoint - currentTotalPoint + newTotalPoint,
+		})
+		if err != nil {
+			return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		}
+	} else if array.ContainAny(
+		[]string{parentTask.Type.String()},
+		[]string{
+			models.TaskTypeStory.String(),
+			models.TaskTypeTask.String(),
+			models.TaskTypeBug.String(),
+		},
+	) {
+		// Modify point for Story, Task, Bug
+		_, err := taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+			ID:            *task.ParentID,
+			ChildrenPoint: parentTask.ChildrenPoint - currentTotalPoint + newTotalPoint,
+		})
+		if err != nil {
+			return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+		}
+
+		// Update children point of the parent task's parent task (EPIC)
+		if parentTask.ParentID != nil {
+			epicParentTask, err := taskRepo.FindByID(ctx, *parentTask.ParentID)
+			if err != nil {
+				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())
+			}
+
+			_, err = taskRepo.UpdateChildrenPoint(ctx, &repositories.UpdateTaskChildrenPointRequest{
+				ID:            *parentTask.ParentID,
+				ChildrenPoint: epicParentTask.ChildrenPoint - currentTotalPoint + newTotalPoint,
 			})
 			if err != nil {
 				return errutils.NewError(exceptions.ErrInternalError, errutils.InternalServerError).WithDebugMessage(err.Error())

--- a/internal/adapters/repositories/mongo/mongo_task_comment_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_comment_repo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cnc-csku/task-nexus/task-management/domain/repositories"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 type mongoTaskCommentRepo struct {
@@ -47,7 +48,9 @@ func (m *mongoTaskCommentRepo) FindByTaskID(ctx context.Context, taskID bson.Obj
 	f := NewTaskCommentFilter()
 	f.WithTaskID(taskID)
 
-	cursor, err := m.collection.Find(ctx, f)
+	o := options.Find().SetSort(bson.M{"created_at": -1})
+
+	cursor, err := m.collection.Find(ctx, f, o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request includes significant refactoring and improvements to the task service implementation. The changes focus on simplifying the code, improving maintainability, and enhancing functionality related to task assignees and parent-child task relationships.

Refactoring and Code Simplification:

* Removed redundant methods `validateParentTaskType`, `getDoneStatuses`, `getParentTasksMap`, `updatePreviousParentTask`, `updateChildrenPointOfPreviousParentTask`, and `updateParentTaskPoints` from `task_service.go` and moved them to `task_service_helper.go` for better modularization. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL362-R385) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL952-L982) [[3]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1350-L1445) [[4]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1718-R1588) [[5]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1782-L1851) [[6]](diffhunk://#diff-39fa7da9376f627cda48c3c49fe4ed955361e16568e759efd63246e23e2c264dR5-R164) [[7]](diffhunk://#diff-39fa7da9376f627cda48c3c49fe4ed955361e16568e759efd63246e23e2c264dR259-R337)

Enhancements to Task Assignees Management:

* Added logic to handle the deletion of points from assignees when a Level 1 parent task (Story, Task, Bug) has assignees with points.
* Simplified the logic for updating assignees by consolidating the handling of points for subtasks and Level 1 tasks without children. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1718-R1588) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1740-R1630)

Improved Parent-Child Task Relationship Handling:

* Enhanced the handling of points and children status updates for parent tasks when their child tasks are updated or reassigned. [[1]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1350-L1445) [[2]](diffhunk://#diff-e324ee9ea5690147871f0877d638045b7d86256606819560b83923b89da8b28eL1782-L1851) [[3]](diffhunk://#diff-39fa7da9376f627cda48c3c49fe4ed955361e16568e759efd63246e23e2c264dR259-R337)

These changes collectively improve the clarity and maintainability of the task service code while ensuring that task relationships and assignee points are managed more effectively.