### PR TITLE
feat: update point for level 1 and 2 tasks.

### DIFF
--- a/domain/repositories/task_repo.go
+++ b/domain/repositories/task_repo.go
@@ -39,6 +39,8 @@ type TaskRepository interface {
 	BulkUpdateCurrentSprintID(ctx context.Context, in *BulkUpdateCurrentSprintIDRequest) error
 	FindByCurrentSprintIDs(ctx context.Context, sprintIDs []bson.ObjectID) ([]*models.Task, error)
 	UpdateManyTasksStatus(ctx context.Context, in *UpdateManyTasksStatusRequest) error
+	UpdateStartDateAndDueDate(ctx context.Context, in *UpdateTaskStartDateAndDueDateRequest) (*models.Task, error)
+	BulkUpdateStartDateAndDueDate(ctx context.Context, in *BulkUpdateStartDateAndDueDateRequest) error
 }
 
 type CreateTaskRequest struct {
@@ -172,5 +174,19 @@ type BulkUpdateCurrentSprintIDRequest struct {
 type UpdateManyTasksStatusRequest struct {
 	TaskIDs   []bson.ObjectID
 	Status    string
+	UpdatedBy bson.ObjectID
+}
+
+type UpdateTaskStartDateAndDueDateRequest struct {
+	ID        bson.ObjectID
+	StartDate *time.Time
+	DueDate   *time.Time
+	UpdatedBy bson.ObjectID
+}
+
+type BulkUpdateStartDateAndDueDateRequest struct {
+	TaskIDs   []bson.ObjectID
+	StartDate *time.Time
+	DueDate   *time.Time
 	UpdatedBy bson.ObjectID
 }

--- a/internal/adapters/repositories/mongo/mongo_task_bson.go
+++ b/internal/adapters/repositories/mongo/mongo_task_bson.go
@@ -258,3 +258,12 @@ func (u taskUpdate) UpdateAttributes(in *repositories.UpdateTaskAttributesReques
 		"updated_by": in.UpdatedBy,
 	}
 }
+
+func (u taskUpdate) UpdateStartDateAndDueDate(startDate, dueDate *time.Time, updatedBy bson.ObjectID) {
+	u["$set"] = bson.M{
+		"start_date": startDate,
+		"due_date":   dueDate,
+		"updated_at": time.Now(),
+		"updated_by": updatedBy,
+	}
+}

--- a/internal/adapters/repositories/mongo/mongo_task_repo.go
+++ b/internal/adapters/repositories/mongo/mongo_task_repo.go
@@ -579,3 +579,33 @@ func (m *mongoTaskRepo) UpdateManyTasksStatus(ctx context.Context, in *repositor
 
 	return nil
 }
+
+func (m *mongoTaskRepo) UpdateStartDateAndDueDate(ctx context.Context, in *repositories.UpdateTaskStartDateAndDueDateRequest) (*models.Task, error) {
+	f := NewTaskFilter()
+	f.WithID(in.ID)
+
+	u := NewTaskUpdate()
+	u.UpdateStartDateAndDueDate(in.StartDate, in.DueDate, in.UpdatedBy)
+
+	err := m.collection.FindOneAndUpdate(ctx, f, u).Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return m.FindByID(ctx, in.ID)
+}
+
+func (m *mongoTaskRepo) BulkUpdateStartDateAndDueDate(ctx context.Context, in *repositories.BulkUpdateStartDateAndDueDateRequest) error {
+	f := NewTaskFilter()
+	f.WithIDs(in.TaskIDs)
+
+	u := NewTaskUpdate()
+	u.UpdateStartDateAndDueDate(in.StartDate, in.DueDate, in.UpdatedBy)
+
+	_, err := m.collection.UpdateMany(ctx, f, u)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request includes a change to the `UpdateAssignees` method in the `taskServiceImpl` class, which modifies how assignee points are handled and appended to the list of assignees.

Changes to `UpdateAssignees` method:

* Added `Point` field to the `UpdateTaskAssigneesRequestAssignee` struct and ensured it is always set for each assignee.
* Simplified the conditional logic to set points for subtasks and level 1 tasks without children by removing redundant code and ensuring points are appended correctly.